### PR TITLE
crypto: fix generic-array version

### DIFF
--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -154,7 +154,7 @@ der = { version = "0.7", default-features = false }
 ecdsa = { version = "0.16", default-features = false, features = ["signing", "verifying", "der"] }
 ed25519-dalek = { version = "2.0.0-rc.3", default-features = false, features = ["zeroize"] }
 elliptic-curve = { version = "0.13", default-features = false, features = ["ecdh", "arithmetic", "sec1"] }
-generic-array = { version = "1", default-features = false, features = ["const-default", "serde", "zeroize"] }
+generic-array = { version = "1.1.*", default-features = false, features = ["const-default", "serde", "zeroize"] }
 getrandom = { version = "0.2", default-features = false, optional = true }
 lazy_static = { version = "1.4", default-features = false, features = ["spin_no_std"], optional = true }
 more-asserts = { version = "0.3", default-features = false, optional = true }


### PR DESCRIPTION
v1.2 isn't supported by our MSRV