### PR TITLE
crypto: `Mac` should not require fixed-size keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "spideroak-crypto"
-version = "0.2.1"
+version = "0.3.0-pre.1"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,6 +1019,7 @@ dependencies = [
  "spin",
  "subtle",
  "tempfile",
+ "thiserror",
  "typenum",
  "wycheproof",
  "zeroize",
@@ -1099,6 +1100,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -119,6 +119,7 @@ std = [
 	"sha3-utils/std",
 	"spin?/std",
 	"subtle/std",
+	"thiserror/std",
 	"zeroize/std",
 ]
 
@@ -175,6 +176,7 @@ sha2 = { version = "0.10", default-features = false }
 sha3-utils = { version = "0.3.0", default-features = false }
 spin = { workspace = true, default-features = false, features = ["mutex", "once", "spin_mutex"], optional = true }
 subtle = { version = "2.5", default-features = false, features = ["core_hint_black_box"] }
+thiserror = { version = "2", default-features = false }
 typenum = { version = "1", default-features = false, features = ["const-generics"] }
 # Only pulled into non-dev builds if `test_util` is enabled. It
 # won't bloat release builds, though, since users of this crate

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spideroak-crypto"
 description = "SpiderOak's cryptography library"
-version = "0.2.1"
+version = "0.3.0-pre.1"
 authors.workspace = true
 edition.workspace = true
 license = "BSD-3-Clause"

--- a/crates/crypto/src/aead.rs
+++ b/crates/crypto/src/aead.rs
@@ -27,7 +27,7 @@ pub use crate::hpke::AeadId;
 use crate::{
     csprng::{Csprng, Random},
     kdf::{Expand, Kdf, KdfError, Prk},
-    keys::{raw_key, FixedLength, SecretKey, SecretKeyBytes},
+    keys::{raw_key, SecretKey, SecretKeyBytes},
     util::const_assert,
     zeroize::Zeroize,
 };
@@ -410,7 +410,7 @@ pub trait Aead {
         };
 
     /// The key used by the [`Aead`].
-    type Key: SecretKey + FixedLength<Size = Self::KeySize>;
+    type Key: SecretKey<Size = Self::KeySize>;
 
     /// Creates a new [`Aead`].
     fn new(key: &Self::Key) -> Self;
@@ -539,7 +539,7 @@ pub trait Aead {
 
 /// Shorthand which the compiler does not understand without
 /// a good amount of hand holding.
-pub type KeyData<A> = SecretKeyBytes<<<A as Aead>::Key as FixedLength>::Size>;
+pub type KeyData<A> = SecretKeyBytes<<<A as Aead>::Key as SecretKey>::Size>;
 
 /// An authentication tag.
 pub type Tag<A> = GenericArray<u8, <A as Aead>::Overhead>;
@@ -1358,7 +1358,7 @@ mod committing {
                     };
                     let mut key_bytes = $crate::generic_array::GenericArray::<
                         u8,
-                        <<$inner as $crate::aead::Aead>::Key as $crate::keys::FixedLength>::Size,
+                        <<$inner as $crate::aead::Aead>::Key as $crate::keys::SecretKey>::Size,
                     >::default();
                     let k = ::core::cmp::min(tag.len(), key_bytes.as_slice().len());
                     key_bytes

--- a/crates/crypto/src/bearssl.rs
+++ b/crates/crypto/src/bearssl.rs
@@ -39,7 +39,7 @@ use crate::{
     hmac::hmac_impl,
     import::{ExportError, Import, ImportError},
     kem::{dhkem_impl, DecapKey, Ecdh, EcdhError, EncapKey, SharedSecret},
-    keys::{FixedLength, PublicKey, SecretKey, SecretKeyBytes},
+    keys::{PublicKey, SecretKey, SecretKeyBytes},
     signer::{PkError, Signer, SignerError, SignerId, SigningKey, VerifyingKey},
     zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing},
 };
@@ -404,16 +404,12 @@ macro_rules! ecdh_impl {
         }
 
         impl SecretKey for $sk {
-            type Secret = SecretKeyBytes<<$curve as Curve>::ScalarSize>;
+            type Size = <$curve as Curve>::ScalarSize;
 
             #[inline]
-            fn try_export_secret(&self) -> Result<Self::Secret, ExportError> {
+            fn try_export_secret(&self) -> Result<SecretKeyBytes<Self::Size>, ExportError> {
                 Ok(SecretKeyBytes::new(self.kbuf.0.into()))
             }
-        }
-
-        impl FixedLength for $sk {
-            type Size = <$curve as Curve>::ScalarSize;
         }
 
         impl Random for $sk {
@@ -465,10 +461,10 @@ macro_rules! ecdh_impl {
             }
         }
 
-        impl Import<SecretKeyBytes<<Self as FixedLength>::Size>> for $sk {
+        impl Import<SecretKeyBytes<<Self as SecretKey>::Size>> for $sk {
             #[inline]
             fn import(
-                data: SecretKeyBytes<<Self as FixedLength>::Size>,
+                data: SecretKeyBytes<<Self as SecretKey>::Size>,
             ) -> Result<Self, ImportError> {
                 Self::import(data.as_bytes())
             }
@@ -710,16 +706,12 @@ macro_rules! ecdsa_impl {
         }
 
         impl SecretKey for $sk {
-            type Secret = SecretKeyBytes<<$curve as Curve>::ScalarSize>;
+            type Size = <$curve as Curve>::ScalarSize;
 
             #[inline]
-            fn try_export_secret(&self) -> Result<Self::Secret, ExportError> {
+            fn try_export_secret(&self) -> Result<SecretKeyBytes<Self::Size>, ExportError> {
                 Ok(SecretKeyBytes::new(self.kbuf.0.into()))
             }
-        }
-
-        impl FixedLength for $sk {
-            type Size = <$curve as Curve>::ScalarSize;
         }
 
         impl Random for $sk {

--- a/crates/crypto/src/block.rs
+++ b/crates/crypto/src/block.rs
@@ -1,0 +1,17 @@
+//! Operations on blocks.
+
+#![forbid(unsafe_code)]
+
+use generic_array::{ArrayLength, GenericArray};
+
+/// Implemented by types that operate on blocks.
+///
+/// For example, block ciphers or the Merkle-Damgård
+/// construction.
+pub trait BlockSize {
+    /// The size in bytes of the block.
+    type BlockSize: ArrayLength;
+}
+
+/// A block.
+pub type Block<S> = GenericArray<u8, <S as BlockSize>::BlockSize>;

--- a/crates/crypto/src/ed25519.rs
+++ b/crates/crypto/src/ed25519.rs
@@ -19,7 +19,7 @@ use crate::{
     csprng::{Csprng, Random},
     hex::ToHex,
     import::{try_import, ExportError, Import, ImportError},
-    keys::{FixedLength, PublicKey, SecretKey, SecretKeyBytes},
+    keys::{PublicKey, SecretKey, SecretKeyBytes},
     signer::{self, PkError, Signer, SignerError, SignerId},
     zeroize::ZeroizeOnDrop,
 };
@@ -68,16 +68,12 @@ impl signer::SigningKey<Ed25519> for SigningKey {
 }
 
 impl SecretKey for SigningKey {
-    type Secret = SecretKeyBytes<U32>;
+    type Size = U32;
 
     #[inline]
-    fn try_export_secret(&self) -> Result<Self::Secret, ExportError> {
+    fn try_export_secret(&self) -> Result<SecretKeyBytes<Self::Size>, ExportError> {
         Ok(SecretKeyBytes::new(self.0.to_bytes().into()))
     }
-}
-
-impl FixedLength for SigningKey {
-    type Size = U32;
 }
 
 impl Random for SigningKey {

--- a/crates/crypto/src/ed25519.rs
+++ b/crates/crypto/src/ed25519.rs
@@ -76,8 +76,10 @@ impl SecretKey for SigningKey {
         Self(dalek::SigningKey::from_bytes(&sk))
     }
 
+    type Secret = SecretKeyBytes<U32>;
+
     #[inline]
-    fn try_export_secret(&self) -> Result<SecretKeyBytes<Self::Size>, ExportError> {
+    fn try_export_secret(&self) -> Result<Self::Secret, ExportError> {
         Ok(SecretKeyBytes::new(self.0.to_bytes().into()))
     }
 }

--- a/crates/crypto/src/hash.rs
+++ b/crates/crypto/src/hash.rs
@@ -3,7 +3,6 @@
 #![forbid(unsafe_code)]
 
 use core::{
-    borrow::{Borrow, BorrowMut},
     fmt::{self, Debug},
     num::NonZeroU16,
     ops::{Deref, DerefMut},
@@ -65,12 +64,6 @@ pub trait Hash: Clone {
     type DigestSize: ArrayLength + IsGreaterOrEqual<U32> + IsLess<U65536> + 'static;
     /// Shorthand for [`DigestSize`][Self::DigestSize].
     const DIGEST_SIZE: usize = Self::DigestSize::USIZE;
-
-    /// The size in bytes of a [`Self::Block`].
-    const BLOCK_SIZE: usize;
-
-    /// An individual block.
-    type Block: Borrow<[u8]> + BorrowMut<[u8]> + Default + Clone;
 
     /// Creates a new [`Hash`].
     fn new() -> Self;
@@ -196,31 +189,6 @@ impl<N: ArrayLength> ConstantTimeEq for Digest<N> {
     #[inline]
     fn ct_eq(&self, other: &Self) -> Choice {
         self.as_bytes().ct_eq(other.as_bytes())
-    }
-}
-
-/// An hash function block.
-#[derive(Clone)]
-pub struct Block<const N: usize>([u8; N]);
-
-impl<const N: usize> Default for Block<N> {
-    #[inline]
-    fn default() -> Self {
-        Self([0u8; N])
-    }
-}
-
-impl<const N: usize> Borrow<[u8]> for Block<N> {
-    #[inline]
-    fn borrow(&self) -> &[u8] {
-        self.0.borrow()
-    }
-}
-
-impl<const N: usize> BorrowMut<[u8]> for Block<N> {
-    #[inline]
-    fn borrow_mut(&mut self) -> &mut [u8] {
-        self.0.borrow_mut()
     }
 }
 

--- a/crates/crypto/src/hmac.rs
+++ b/crates/crypto/src/hmac.rs
@@ -14,7 +14,7 @@ use crate::{
     csprng::{Csprng, Random},
     hash::{Digest, Hash},
     import::{ExportError, Import, ImportError},
-    keys::{FixedLength, SecretKey, SecretKeyBytes},
+    keys::{SecretKey, SecretKeyBytes},
     zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing},
 };
 
@@ -178,20 +178,16 @@ impl<H: Hash + BlockSize> Clone for HmacKey<H> {
 }
 
 impl<H: Hash + BlockSize> SecretKey for HmacKey<H> {
-    type Secret = SecretKeyBytes<H::BlockSize>;
+    type Size = H::BlockSize;
 
     /// Exports the raw key.
     ///
     /// Note: this returns `h(k)` if the original `k` passed to
     /// [`HmacKey::new`] was longer than the block size of `h`.
     #[inline]
-    fn try_export_secret(&self) -> Result<Self::Secret, ExportError> {
+    fn try_export_secret(&self) -> Result<SecretKeyBytes<Self::Size>, ExportError> {
         Ok(SecretKeyBytes::new(self.0.clone()))
     }
-}
-
-impl<H: Hash + BlockSize> FixedLength for HmacKey<H> {
-    type Size = H::BlockSize;
 }
 
 impl<H: Hash + BlockSize> Random for HmacKey<H> {

--- a/crates/crypto/src/hpke.rs
+++ b/crates/crypto/src/hpke.rs
@@ -32,6 +32,7 @@ use crate::{
     import::{ExportError, Import, ImportError},
     kdf::{Context, Expand, Kdf, KdfError, Prk},
     kem::{Kem, KemError},
+    keys::RawSecretBytes,
     AlgId,
 };
 
@@ -526,7 +527,7 @@ impl<K: Kem, F: Kdf, A: Aead + IndCca2> Hpke<K, F, A> {
         let ks_ctx = [&[mode.id()], psk_id_hash.as_bytes(), info_hash.as_bytes()];
 
         //  secret = LabeledExtract(shared_secret, "secret", psk)
-        let secret = Self::labeled_extract(shared_secret.as_ref(), "secret", psk);
+        let secret = Self::labeled_extract(shared_secret.raw_secret_bytes(), "secret", psk);
 
         // key = LabeledExpand(secret, "key", key_schedule_context, Nk)
         let key = Self::labeled_expand(&secret, "key", &ks_ctx)?;

--- a/crates/crypto/src/hpke.rs
+++ b/crates/crypto/src/hpke.rs
@@ -646,7 +646,10 @@ pub struct SendCtx<K: Kem, F: Kdf, A: Aead + IndCca2> {
     export: ExportCtx<K, F, A>,
 }
 
-impl<K: Kem, F: Kdf, A: Aead + IndCca2> SendCtx<K, F, A> {
+impl<K: Kem, F: Kdf, A: Aead + IndCca2> SendCtx<K, F, A>
+where
+    A::Key: for<'a> Import<&'a [u8]>,
+{
     /// The size in bytes of the overhead added to the plaintext.
     pub const OVERHEAD: usize = SealCtx::<A>::OVERHEAD;
 
@@ -689,7 +692,9 @@ impl<K: Kem, F: Kdf, A: Aead + IndCca2> SendCtx<K, F, A> {
     ) -> Result<Seq, HpkeError> {
         self.seal_ctx()?.seal_in_place(data, tag, additional_data)
     }
+}
 
+impl<K: Kem, F: Kdf, A: Aead + IndCca2> SendCtx<K, F, A> {
     /// Exports a secret from the encryption context.
     pub fn export<T>(&self, context: &[u8]) -> Result<T, KdfError>
     where
@@ -726,7 +731,10 @@ impl<A: Aead + IndCca2> SealCtx<A> {
         key: &KeyData<A>,
         base_nonce: &Nonce<A::NonceSize>,
         seq: Seq,
-    ) -> Result<Self, ImportError> {
+    ) -> Result<Self, ImportError>
+    where
+        A::Key: for<'a> Import<&'a [u8]>,
+    {
         let key = A::Key::import(key.as_bytes())?;
         Ok(Self {
             aead: A::new(&key),
@@ -789,7 +797,10 @@ pub struct RecvCtx<K: Kem, F: Kdf, A: Aead + IndCca2> {
     export: ExportCtx<K, F, A>,
 }
 
-impl<K: Kem, F: Kdf, A: Aead + IndCca2> RecvCtx<K, F, A> {
+impl<K: Kem, F: Kdf, A: Aead + IndCca2> RecvCtx<K, F, A>
+where
+    A::Key: for<'a> Import<&'a [u8]>,
+{
     /// The size in bytes of the overhead added to the plaintext.
     pub const OVERHEAD: usize = OpenCtx::<A>::OVERHEAD;
 
@@ -861,7 +872,9 @@ impl<K: Kem, F: Kdf, A: Aead + IndCca2> RecvCtx<K, F, A> {
         self.open_ctx()?
             .open_in_place_at(data, tag, additional_data, seq)
     }
+}
 
+impl<K: Kem, F: Kdf, A: Aead + IndCca2> RecvCtx<K, F, A> {
     /// Exports a secret from the encryption context.
     pub fn export<T>(&self, context: &[u8]) -> Result<T, KdfError>
     where
@@ -898,7 +911,10 @@ impl<A: Aead + IndCca2> OpenCtx<A> {
         key: &KeyData<A>,
         base_nonce: &Nonce<A::NonceSize>,
         seq: Seq,
-    ) -> Result<Self, ImportError> {
+    ) -> Result<Self, ImportError>
+    where
+        A::Key: for<'a> Import<&'a [u8]>,
+    {
         let key = A::Key::import(key.as_bytes())?;
         Ok(Self {
             aead: A::new(&key),

--- a/crates/crypto/src/hpke.rs
+++ b/crates/crypto/src/hpke.rs
@@ -647,10 +647,7 @@ pub struct SendCtx<K: Kem, F: Kdf, A: Aead + IndCca2> {
     export: ExportCtx<K, F, A>,
 }
 
-impl<K: Kem, F: Kdf, A: Aead + IndCca2> SendCtx<K, F, A>
-where
-    A::Key: for<'a> Import<&'a [u8]>,
-{
+impl<K: Kem, F: Kdf, A: Aead + IndCca2> SendCtx<K, F, A> {
     /// The size in bytes of the overhead added to the plaintext.
     pub const OVERHEAD: usize = SealCtx::<A>::OVERHEAD;
 
@@ -693,9 +690,7 @@ where
     ) -> Result<Seq, HpkeError> {
         self.seal_ctx()?.seal_in_place(data, tag, additional_data)
     }
-}
 
-impl<K: Kem, F: Kdf, A: Aead + IndCca2> SendCtx<K, F, A> {
     /// Exports a secret from the encryption context.
     pub fn export<T>(&self, context: &[u8]) -> Result<T, KdfError>
     where
@@ -732,10 +727,7 @@ impl<A: Aead + IndCca2> SealCtx<A> {
         key: &KeyData<A>,
         base_nonce: &Nonce<A::NonceSize>,
         seq: Seq,
-    ) -> Result<Self, ImportError>
-    where
-        A::Key: for<'a> Import<&'a [u8]>,
-    {
+    ) -> Result<Self, ImportError> {
         let key = A::Key::import(key.as_bytes())?;
         Ok(Self {
             aead: A::new(&key),
@@ -798,10 +790,7 @@ pub struct RecvCtx<K: Kem, F: Kdf, A: Aead + IndCca2> {
     export: ExportCtx<K, F, A>,
 }
 
-impl<K: Kem, F: Kdf, A: Aead + IndCca2> RecvCtx<K, F, A>
-where
-    A::Key: for<'a> Import<&'a [u8]>,
-{
+impl<K: Kem, F: Kdf, A: Aead + IndCca2> RecvCtx<K, F, A> {
     /// The size in bytes of the overhead added to the plaintext.
     pub const OVERHEAD: usize = OpenCtx::<A>::OVERHEAD;
 
@@ -873,9 +862,7 @@ where
         self.open_ctx()?
             .open_in_place_at(data, tag, additional_data, seq)
     }
-}
 
-impl<K: Kem, F: Kdf, A: Aead + IndCca2> RecvCtx<K, F, A> {
     /// Exports a secret from the encryption context.
     pub fn export<T>(&self, context: &[u8]) -> Result<T, KdfError>
     where
@@ -912,10 +899,7 @@ impl<A: Aead + IndCca2> OpenCtx<A> {
         key: &KeyData<A>,
         base_nonce: &Nonce<A::NonceSize>,
         seq: Seq,
-    ) -> Result<Self, ImportError>
-    where
-        A::Key: for<'a> Import<&'a [u8]>,
-    {
+    ) -> Result<Self, ImportError> {
         let key = A::Key::import(key.as_bytes())?;
         Ok(Self {
             aead: A::new(&key),

--- a/crates/crypto/src/import.rs
+++ b/crates/crypto/src/import.rs
@@ -165,6 +165,14 @@ pub trait Import<T>: Sized {
     fn import(data: T) -> Result<Self, ImportError>;
 }
 
+/// TODO
+pub trait Export {
+    /// TODO
+    type Secret;
+    /// TODO
+    fn try_export_secret(&self) -> Result<Self::Secret, ExportError>;
+}
+
 /// An error that occurs while exporting secret key material.
 #[derive(Debug, Eq, PartialEq)]
 pub enum ExportError {

--- a/crates/crypto/src/import.rs
+++ b/crates/crypto/src/import.rs
@@ -165,14 +165,6 @@ pub trait Import<T>: Sized {
     fn import(data: T) -> Result<Self, ImportError>;
 }
 
-/// TODO
-pub trait Export {
-    /// TODO
-    type Secret;
-    /// TODO
-    fn try_export_secret(&self) -> Result<Self::Secret, ExportError>;
-}
-
 /// An error that occurs while exporting secret key material.
 #[derive(Debug, Eq, PartialEq)]
 pub enum ExportError {

--- a/crates/crypto/src/kdf.rs
+++ b/crates/crypto/src/kdf.rs
@@ -14,7 +14,10 @@ use typenum::{
 
 #[doc(inline)]
 pub use crate::hpke::KdfId;
-use crate::{keys::SecretKeyBytes, zeroize::ZeroizeOnDrop};
+use crate::{
+    keys::{RawSecretBytes, SecretKeyBytes},
+    zeroize::ZeroizeOnDrop,
+};
 
 /// An error from a [`Kdf`].
 #[derive(Debug, Eq, PartialEq)]
@@ -227,10 +230,9 @@ impl<N: ArrayLength> ConstantTimeEq for Prk<N> {
     }
 }
 
-// TODO(eric): get rid of this. The only use is `Kem::Secret`.
-impl<N: ArrayLength> AsRef<[u8]> for Prk<N> {
+impl<N: ArrayLength> RawSecretBytes for Prk<N> {
     #[inline]
-    fn as_ref(&self) -> &[u8] {
+    fn raw_secret_bytes(&self) -> &[u8] {
         self.as_bytes()
     }
 }

--- a/crates/crypto/src/kem.rs
+++ b/crates/crypto/src/kem.rs
@@ -16,7 +16,7 @@ use crate::{
     csprng::{Csprng, Random},
     import::{Import, ImportError},
     kdf::{Kdf, KdfError, Prk},
-    keys::{PublicKey, SecretKey},
+    keys::{PublicKey, RawSecretBytes, SecretKey},
     signer::PkError,
     zeroize::ZeroizeOnDrop,
 };
@@ -102,7 +102,7 @@ pub trait Kem {
     /// An ephemeral, fixed-length symmetric key.
     ///
     /// The key must be at least 128 bits.
-    type Secret: AsRef<[u8]> + ZeroizeOnDrop;
+    type Secret: RawSecretBytes + ZeroizeOnDrop;
 
     /// An encapsulated [`Self::Secret`].
     type Encap: Borrow<[u8]> + for<'a> Import<&'a [u8]>;

--- a/crates/crypto/src/kem.rs
+++ b/crates/crypto/src/kem.rs
@@ -16,7 +16,7 @@ use crate::{
     csprng::{Csprng, Random},
     import::{Import, ImportError},
     kdf::{Kdf, KdfError, Prk},
-    keys::{FixedLength, PublicKey, SecretKey},
+    keys::{PublicKey, SecretKey},
     signer::PkError,
     zeroize::ZeroizeOnDrop,
 };
@@ -191,7 +191,7 @@ pub trait Kem {
 }
 
 /// An asymmetric private key used to decapsulate keys.
-pub trait DecapKey: SecretKey + FixedLength + Random {
+pub trait DecapKey: SecretKey + Random {
     /// The corresponding public key.
     type EncapKey: EncapKey;
 

--- a/crates/crypto/src/kem.rs
+++ b/crates/crypto/src/kem.rs
@@ -13,10 +13,10 @@ use core::{
 #[doc(inline)]
 pub use crate::hpke::KemId;
 use crate::{
-    csprng::Csprng,
+    csprng::{Csprng, Random},
     import::{Import, ImportError},
     kdf::{Kdf, KdfError, Prk},
-    keys::{PublicKey, SecretKey},
+    keys::{FixedLength, PublicKey, SecretKey},
     signer::PkError,
     zeroize::ZeroizeOnDrop,
 };
@@ -191,7 +191,7 @@ pub trait Kem {
 }
 
 /// An asymmetric private key used to decapsulate keys.
-pub trait DecapKey: SecretKey {
+pub trait DecapKey: SecretKey + FixedLength + Random {
     /// The corresponding public key.
     type EncapKey: EncapKey;
 
@@ -350,7 +350,7 @@ impl<E: Ecdh, F: Kdf> DhKem<E, F> {
         rng: &mut R,
         pkR: &E::PublicKey,
     ) -> Result<(Prk<F::PrkSize>, PubKeyData<E>), KemError> {
-        let skE = E::PrivateKey::new(rng);
+        let skE = E::PrivateKey::random(rng);
         self.encap_deterministically(pkR, skE)
     }
 
@@ -413,7 +413,7 @@ impl<E: Ecdh, F: Kdf> DhKem<E, F> {
         pkR: &E::PublicKey,
         skS: &E::PrivateKey,
     ) -> Result<(Prk<F::PrkSize>, PubKeyData<E>), KemError> {
-        let skE = E::PrivateKey::new(rng);
+        let skE = E::PrivateKey::random(rng);
         self.auth_encap_deterministically(pkR, skS, skE)
     }
 

--- a/crates/crypto/src/keys.rs
+++ b/crates/crypto/src/keys.rs
@@ -17,7 +17,9 @@ use crate::{
 ///
 /// Secret keys are either symmetric keys (e.g., for AES) or
 /// asymmetric private keys (e.g., for ECDH).
-pub trait SecretKey: Clone + ConstantTimeEq + for<'a> Import<&'a [u8]> + ZeroizeOnDrop {
+pub trait SecretKey:
+    Clone + ConstantTimeEq + for<'a> Import<&'a [u8]> + Random + ZeroizeOnDrop
+{
     /// The size in octets of the key.
     type Size: ArrayLength + 'static;
 

--- a/crates/crypto/src/keys.rs
+++ b/crates/crypto/src/keys.rs
@@ -38,6 +38,13 @@ impl<T: RawSecretBytes> RawSecretBytes for &T {
     }
 }
 
+impl RawSecretBytes for [u8] {
+    #[inline]
+    fn raw_secret_bytes(&self) -> &[u8] {
+        self
+    }
+}
+
 /// A fixed-length byte encoding of a [`SecretKey`]'s data.
 #[derive(Clone, Default, ZeroizeOnDrop)]
 #[repr(transparent)]

--- a/crates/crypto/src/keys.rs
+++ b/crates/crypto/src/keys.rs
@@ -297,4 +297,4 @@ pub(crate) use raw_key;
 // TODO(eric): move this somewhere else.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, thiserror::Error)]
 #[error("invalid key length")]
-pub struct InvalidKey(());
+pub struct InvalidKey;

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -17,6 +17,7 @@ pub(crate) use spideroak_crypto_derive::AlgId;
 pub mod aead;
 pub mod asn1;
 pub mod bearssl;
+pub mod block;
 pub mod csprng;
 pub mod default;
 pub mod ec;

--- a/crates/crypto/src/mac.rs
+++ b/crates/crypto/src/mac.rs
@@ -90,10 +90,14 @@ pub trait Mac: Clone + Sized {
     /// Must be at least 32 octets and less than 2¹⁶ octets.
     type MinKeySize: ArrayLength + IsGreaterOrEqual<U32> + IsLess<U65536> + 'static;
 
-    /// Creates a new [`Mac`].
+    /// Creates a [`Mac`] with a fixed-length key.
     fn new(key: &Self::Key) -> Self;
 
-    /// Attempts to create a new [`Mac`].
+    /// Attempts to create a new [`Mac`] with a variable-length
+    /// key.
+    ///
+    /// It returns [`InvalidKey`] if `key` is shorter than
+    /// [`MinKeySize`][Self::MinKeySize].
     fn try_new(key: &[u8]) -> Result<Self, InvalidKey>;
 
     /// Adds `data` to the running tag.

--- a/crates/crypto/src/mac.rs
+++ b/crates/crypto/src/mac.rs
@@ -69,7 +69,7 @@ pub enum MacId {
 /// * Be a PRF
 ///
 /// Examples of keyed MAC algorithms that fulfill these
-/// requirements include HMAC-SHA-512 (for |K| in [L, B]) and
+/// requirements include HMAC-SHA-512 (for |K| >= 256) and
 /// KMAC256 (for |K| >= 256).
 pub trait Mac: Clone + Sized {
     /// Uniquely identifies the MAC algorithm.

--- a/crates/crypto/src/mac.rs
+++ b/crates/crypto/src/mac.rs
@@ -9,10 +9,7 @@ use core::{
 
 use generic_array::{ArrayLength, GenericArray};
 use subtle::{Choice, ConstantTimeEq};
-use typenum::{
-    type_operators::{IsGreaterOrEqual, IsLess},
-    U32, U48, U64, U65536,
-};
+use typenum::{IsGreaterOrEqual, IsLess, U32, U48, U64, U65536};
 
 use crate::{
     keys::{raw_key, InvalidKey, SecretKey},
@@ -65,7 +62,7 @@ pub enum MacId {
 /// * Produce tags at least 256 bits long
 /// * Have at minimum a 256-bit security level
 /// * Reject insecure keys
-/// * Be at least strongly EUF-CMA secure
+/// * Be at least strongly EUF-CMA (SUF-CMA) secure
 /// * Be a PRF
 ///
 /// Examples of keyed MAC algorithms that fulfill these
@@ -82,25 +79,45 @@ pub trait Mac: Clone + Sized {
     /// Must be at least 32 octets and less than 2¹⁶ octets.
     type TagSize: ArrayLength + IsGreaterOrEqual<U32> + IsLess<U65536> + 'static;
 
-    /// The key used by the [`Mac`].
-    type Key: SecretKey;
-    /// The minimum allowed size in octets of a key used by this
-    /// [`Mac`].
+    /// A fixed-length key used by [`new`][Self::new].
     ///
-    /// Must be at least 32 octets and less than 2¹⁶ octets.
-    type MinKeySize: ArrayLength + IsGreaterOrEqual<U32> + IsLess<U65536> + 'static;
+    /// # Note About Variable Length Keys
+    ///
+    /// Some MACs (HMAC, KMAC, etc.) accept variable length keys
+    /// and do not have a fixed key length. For these MACs,
+    /// [`Key`][Self::Key] should have an appropriate default key
+    /// length. For example, KMAC256 should use a 256-bit key.
+    type Key: SecretKey<Size = Self::KeySize>;
+    /// The size in octets of [`Key`][Self::Key].
+    ///
+    /// Must be at least [`MinKeySize`][Self::MinKeySize] or 32
+    /// octets (whichever is greater) and less than 2¹⁶ octets.
+    type KeySize: ArrayLength
+        + IsGreaterOrEqual<Self::MinKeySize>
+        + IsGreaterOrEqual<U32>
+        + IsLess<U65536>
+        + 'static;
 
     /// Creates a [`Mac`] with a fixed-length key.
     fn new(key: &Self::Key) -> Self;
 
-    /// Attempts to create a new [`Mac`] with a variable-length
+    /// The minimum allowed size in octets of the variable length
+    /// key used by [`try_new`][Self::try_new].
+    ///
+    /// Must be at least 32 octets and less than 2¹⁶ octets.
+    type MinKeySize: ArrayLength + IsGreaterOrEqual<U32> + IsLess<U65536> + 'static;
+
+    /// Attempts to create a new `Mac` with a variable-length
     /// key.
     ///
     /// It returns [`InvalidKey`] if `key` is shorter than
     /// [`MinKeySize`][Self::MinKeySize].
+    ///
+    /// A `Mac` is allowed to require `key.len()` to be exactly
+    /// [`KeySize`][Self::KeySize].
     fn try_new(key: &[u8]) -> Result<Self, InvalidKey>;
 
-    /// Adds `data` to the running tag.
+    /// Updates the current MAC with `data`.
     fn update(&mut self, data: &[u8]);
 
     /// Returns the current authentication tag.

--- a/crates/crypto/src/rust.rs
+++ b/crates/crypto/src/rust.rs
@@ -38,7 +38,7 @@ use crate::{
     hmac::hmac_impl,
     import::{try_from_slice, ExportError, Import, ImportError},
     kem::{dhkem_impl, DecapKey, Ecdh, EcdhError, EncapKey},
-    keys::{FixedLength, PublicKey, SecretKey, SecretKeyBytes},
+    keys::{PublicKey, SecretKey, SecretKeyBytes},
     signer::{Signature, Signer, SignerError, SignerId, SigningKey, VerifyingKey},
     zeroize::ZeroizeOnDrop,
 };
@@ -233,18 +233,14 @@ macro_rules! ecdh_impl {
         }
 
         impl SecretKey for $sk {
-            type Secret = SecretKeyBytes<FieldBytesSize<$curve>>;
+            type Size = FieldBytesSize<$curve>;
 
             #[inline]
-            fn try_export_secret(&self) -> Result<Self::Secret, ExportError> {
+            fn try_export_secret(&self) -> Result<SecretKeyBytes<Self::Size>, ExportError> {
                 // Mismatched GenericArray versions, yay.
                 let secret: [u8; FieldBytesSize::<$curve>::USIZE] = self.0.to_bytes().into();
                 Ok(SecretKeyBytes::new(secret.into()))
             }
-        }
-
-        impl FixedLength for $sk {
-            type Size = FieldBytesSize<$curve>;
         }
 
         impl Random for $sk {
@@ -376,18 +372,14 @@ macro_rules! ecdsa_impl {
         }
 
         impl SecretKey for $sk {
-            type Secret = SecretKeyBytes<FieldBytesSize<$curve>>;
+            type Size = FieldBytesSize<$curve>;
 
             #[inline]
-            fn try_export_secret(&self) -> Result<Self::Secret, ExportError> {
+            fn try_export_secret(&self) -> Result<SecretKeyBytes<Self::Size>, ExportError> {
                 // Mismatched GenericArray versions, yay.
                 let secret: [u8; FieldBytesSize::<$curve>::USIZE] = self.0.to_bytes().into();
                 Ok(SecretKeyBytes::new(secret.into()))
             }
-        }
-
-        impl FixedLength for $sk {
-            type Size = FieldBytesSize<$curve>;
         }
 
         impl Random for $sk {

--- a/crates/crypto/src/rust.rs
+++ b/crates/crypto/src/rust.rs
@@ -240,8 +240,10 @@ macro_rules! ecdh_impl {
                 Self(sk)
             }
 
+            type Secret = SecretKeyBytes<FieldBytesSize<$curve>>;
+
             #[inline]
-            fn try_export_secret(&self) -> Result<SecretKeyBytes<Self::Size>, ExportError> {
+            fn try_export_secret(&self) -> Result<Self::Secret, ExportError> {
                 // Mismatched GenericArray versions, yay.
                 let secret: [u8; FieldBytesSize::<$curve>::USIZE] = self.0.to_bytes().into();
                 Ok(SecretKeyBytes::new(secret.into()))
@@ -377,8 +379,10 @@ macro_rules! ecdsa_impl {
                 Self(sk)
             }
 
+            type Secret = SecretKeyBytes<FieldBytesSize<$curve>>;
+
             #[inline]
-            fn try_export_secret(&self) -> Result<SecretKeyBytes<Self::Size>, ExportError> {
+            fn try_export_secret(&self) -> Result<Self::Secret, ExportError> {
                 // Mismatched GenericArray versions, yay.
                 let secret: [u8; FieldBytesSize::<$curve>::USIZE] = self.0.to_bytes().into();
                 Ok(SecretKeyBytes::new(secret.into()))

--- a/crates/crypto/src/signer.rs
+++ b/crates/crypto/src/signer.rs
@@ -13,8 +13,9 @@ use buggy::Bug;
 
 use crate::{
     asn1::EncodingError,
+    csprng::Random,
     import::Import,
-    keys::{PublicKey, SecretKey},
+    keys::{FixedLength, PublicKey, SecretKey},
     AlgId,
 };
 
@@ -148,7 +149,7 @@ pub trait Signer {
 }
 
 /// An asymmetric secret key used to create digital signatures.
-pub trait SigningKey<T: Signer + ?Sized>: SecretKey {
+pub trait SigningKey<T: Signer + ?Sized>: SecretKey + FixedLength + Random {
     /// Returns the signature over `msg`, which must NOT be
     /// pre-hashed.
     fn sign(&self, msg: &[u8]) -> Result<T::Signature, SignerError>;

--- a/crates/crypto/src/signer.rs
+++ b/crates/crypto/src/signer.rs
@@ -15,7 +15,7 @@ use crate::{
     asn1::EncodingError,
     csprng::Random,
     import::Import,
-    keys::{FixedLength, PublicKey, SecretKey},
+    keys::{PublicKey, SecretKey},
     AlgId,
 };
 
@@ -149,7 +149,7 @@ pub trait Signer {
 }
 
 /// An asymmetric secret key used to create digital signatures.
-pub trait SigningKey<T: Signer + ?Sized>: SecretKey + FixedLength + Random {
+pub trait SigningKey<T: Signer + ?Sized>: SecretKey + Random {
     /// Returns the signature over `msg`, which must NOT be
     /// pre-hashed.
     fn sign(&self, msg: &[u8]) -> Result<T::Signature, SignerError>;

--- a/crates/crypto/src/test_util/aead.rs
+++ b/crates/crypto/src/test_util/aead.rs
@@ -9,8 +9,7 @@ use more_asserts::assert_ge;
 use super::{assert_all_zero, assert_ct_ne};
 use crate::{
     aead::{Aead, Nonce, OpenError},
-    csprng::Csprng,
-    keys::SecretKey,
+    csprng::{Csprng, Random},
 };
 
 /// Invokes `callback` for each AEAD test.
@@ -103,7 +102,12 @@ const GOLDEN: &[u8] = b"hello, world!";
 const AD: &[u8] = b"some additional data";
 
 /// A basic positive test.
-pub fn test_basic<A: Aead, R: Csprng>(_rng: &mut R) {
+pub fn test_basic<A, R>(_rng: &mut R)
+where
+    A: Aead,
+    A::Key: Random,
+    R: Csprng,
+{
     // The minimum key size is 128 bits.
     assert_ge!(A::KEY_SIZE, 16);
     // Must be at least 2^32-1.
@@ -118,15 +122,25 @@ pub fn test_basic<A: Aead, R: Csprng>(_rng: &mut R) {
 }
 
 /// Tests that `Aead::Key::new` returns unique keys.
-pub fn test_new_key<A: Aead, R: Csprng>(rng: &mut R) {
-    let k1 = A::Key::new(rng);
-    let k2 = A::Key::new(rng);
+pub fn test_new_key<A, R>(rng: &mut R)
+where
+    A: Aead,
+    A::Key: Random,
+    R: Csprng,
+{
+    let k1 = A::Key::random(rng);
+    let k2 = A::Key::random(rng);
     assert_ct_ne!(k1, k2);
 }
 
 /// A round-trip positive test.
-pub fn test_round_trip<A: Aead, R: Csprng>(rng: &mut R) {
-    let key = A::Key::new(rng);
+pub fn test_round_trip<A, R>(rng: &mut R)
+where
+    A: Aead,
+    A::Key: Random,
+    R: Csprng,
+{
+    let key = A::Key::random(rng);
     let nonce = Nonce::<A::NonceSize>::default();
     assert_all_zero!(nonce);
 
@@ -149,8 +163,13 @@ pub fn test_round_trip<A: Aead, R: Csprng>(rng: &mut R) {
 }
 
 /// An in-place round-trip positive test.
-pub fn test_in_place_round_trip<A: Aead, R: Csprng>(rng: &mut R) {
-    let key = A::Key::new(rng);
+pub fn test_in_place_round_trip<A, R>(rng: &mut R)
+where
+    A: Aead,
+    A::Key: Random,
+    R: Csprng,
+{
+    let key = A::Key::random(rng);
     let nonce = Nonce::<A::NonceSize>::default();
     assert_all_zero!(nonce);
 
@@ -176,12 +195,17 @@ pub fn test_in_place_round_trip<A: Aead, R: Csprng>(rng: &mut R) {
 }
 
 /// Decryption should fail with an incorrect key.
-pub fn test_bad_key<A: Aead, R: Csprng>(rng: &mut R) {
+pub fn test_bad_key<A, R>(rng: &mut R)
+where
+    A: Aead,
+    A::Key: Random,
+    R: Csprng,
+{
     let nonce = Nonce::<A::NonceSize>::default();
     assert_all_zero!(nonce);
 
     let ciphertext = {
-        let key = A::Key::new(rng);
+        let key = A::Key::random(rng);
 
         let mut dst = vec![0u8; GOLDEN.len() + A::OVERHEAD];
         A::new(&key)
@@ -190,7 +214,7 @@ pub fn test_bad_key<A: Aead, R: Csprng>(rng: &mut R) {
         dst
     };
 
-    let key = A::Key::new(rng);
+    let key = A::Key::random(rng);
     let mut dst = vec![0u8; ciphertext.len() - A::OVERHEAD];
     let err = A::new(&key)
         .open(&mut dst[..], nonce.as_ref(), &ciphertext, AD)
@@ -199,8 +223,13 @@ pub fn test_bad_key<A: Aead, R: Csprng>(rng: &mut R) {
 }
 
 /// Decryption should fail with an incorrect nonce.
-pub fn test_bad_nonce<A: Aead, R: Csprng>(rng: &mut R) {
-    let key = A::Key::new(rng);
+pub fn test_bad_nonce<A, R>(rng: &mut R)
+where
+    A: Aead,
+    A::Key: Random,
+    R: Csprng,
+{
+    let key = A::Key::random(rng);
 
     let ciphertext = {
         let mut nonce = Nonce::<A::NonceSize>::default();
@@ -226,8 +255,13 @@ pub fn test_bad_nonce<A: Aead, R: Csprng>(rng: &mut R) {
 }
 
 /// Decryption should fail with a modified AD.
-pub fn test_bad_ad<A: Aead, R: Csprng>(rng: &mut R) {
-    let key = A::Key::new(rng);
+pub fn test_bad_ad<A, R>(rng: &mut R)
+where
+    A: Aead,
+    A::Key: Random,
+    R: Csprng,
+{
+    let key = A::Key::random(rng);
     let nonce = Nonce::<A::NonceSize>::default();
     assert_all_zero!(nonce);
 
@@ -247,8 +281,13 @@ pub fn test_bad_ad<A: Aead, R: Csprng>(rng: &mut R) {
 }
 
 /// Decryption should fail with a modified ciphertext.
-pub fn test_bad_ciphertext<A: Aead, R: Csprng>(rng: &mut R) {
-    let key = A::Key::new(rng);
+pub fn test_bad_ciphertext<A, R>(rng: &mut R)
+where
+    A: Aead,
+    A::Key: Random,
+    R: Csprng,
+{
+    let key = A::Key::random(rng);
     let nonce = Nonce::<A::NonceSize>::default();
     assert_all_zero!(nonce);
 
@@ -271,8 +310,13 @@ pub fn test_bad_ciphertext<A: Aead, R: Csprng>(rng: &mut R) {
 
 /// Decryption should fail with a modified authentication
 /// tag.
-pub fn test_bad_tag<A: Aead, R: Csprng>(rng: &mut R) {
-    let key = A::Key::new(rng);
+pub fn test_bad_tag<A, R>(rng: &mut R)
+where
+    A: Aead,
+    A::Key: Random,
+    R: Csprng,
+{
+    let key = A::Key::random(rng);
     let nonce = Nonce::<A::NonceSize>::default();
     assert_all_zero!(nonce);
 

--- a/crates/crypto/src/test_util/aead.rs
+++ b/crates/crypto/src/test_util/aead.rs
@@ -102,12 +102,7 @@ const GOLDEN: &[u8] = b"hello, world!";
 const AD: &[u8] = b"some additional data";
 
 /// A basic positive test.
-pub fn test_basic<A, R>(_rng: &mut R)
-where
-    A: Aead,
-    A::Key: Random,
-    R: Csprng,
-{
+pub fn test_basic<A: Aead, R: Csprng>(_rng: &mut R) {
     // The minimum key size is 128 bits.
     assert_ge!(A::KEY_SIZE, 16);
     // Must be at least 2^32-1.
@@ -122,24 +117,14 @@ where
 }
 
 /// Tests that `Aead::Key::new` returns unique keys.
-pub fn test_new_key<A, R>(rng: &mut R)
-where
-    A: Aead,
-    A::Key: Random,
-    R: Csprng,
-{
+pub fn test_new_key<A: Aead, R: Csprng>(rng: &mut R) {
     let k1 = A::Key::random(rng);
     let k2 = A::Key::random(rng);
     assert_ct_ne!(k1, k2);
 }
 
 /// A round-trip positive test.
-pub fn test_round_trip<A, R>(rng: &mut R)
-where
-    A: Aead,
-    A::Key: Random,
-    R: Csprng,
-{
+pub fn test_round_trip<A: Aead, R: Csprng>(rng: &mut R) {
     let key = A::Key::random(rng);
     let nonce = Nonce::<A::NonceSize>::default();
     assert_all_zero!(nonce);
@@ -163,12 +148,7 @@ where
 }
 
 /// An in-place round-trip positive test.
-pub fn test_in_place_round_trip<A, R>(rng: &mut R)
-where
-    A: Aead,
-    A::Key: Random,
-    R: Csprng,
-{
+pub fn test_in_place_round_trip<A: Aead, R: Csprng>(rng: &mut R) {
     let key = A::Key::random(rng);
     let nonce = Nonce::<A::NonceSize>::default();
     assert_all_zero!(nonce);
@@ -195,12 +175,7 @@ where
 }
 
 /// Decryption should fail with an incorrect key.
-pub fn test_bad_key<A, R>(rng: &mut R)
-where
-    A: Aead,
-    A::Key: Random,
-    R: Csprng,
-{
+pub fn test_bad_key<A: Aead, R: Csprng>(rng: &mut R) {
     let nonce = Nonce::<A::NonceSize>::default();
     assert_all_zero!(nonce);
 
@@ -223,12 +198,7 @@ where
 }
 
 /// Decryption should fail with an incorrect nonce.
-pub fn test_bad_nonce<A, R>(rng: &mut R)
-where
-    A: Aead,
-    A::Key: Random,
-    R: Csprng,
-{
+pub fn test_bad_nonce<A: Aead, R: Csprng>(rng: &mut R) {
     let key = A::Key::random(rng);
 
     let ciphertext = {
@@ -255,12 +225,7 @@ where
 }
 
 /// Decryption should fail with a modified AD.
-pub fn test_bad_ad<A, R>(rng: &mut R)
-where
-    A: Aead,
-    A::Key: Random,
-    R: Csprng,
-{
+pub fn test_bad_ad<A: Aead, R: Csprng>(rng: &mut R) {
     let key = A::Key::random(rng);
     let nonce = Nonce::<A::NonceSize>::default();
     assert_all_zero!(nonce);
@@ -281,12 +246,7 @@ where
 }
 
 /// Decryption should fail with a modified ciphertext.
-pub fn test_bad_ciphertext<A, R>(rng: &mut R)
-where
-    A: Aead,
-    A::Key: Random,
-    R: Csprng,
-{
+pub fn test_bad_ciphertext<A: Aead, R: Csprng>(rng: &mut R) {
     let key = A::Key::random(rng);
     let nonce = Nonce::<A::NonceSize>::default();
     assert_all_zero!(nonce);
@@ -310,12 +270,7 @@ where
 
 /// Decryption should fail with a modified authentication
 /// tag.
-pub fn test_bad_tag<A, R>(rng: &mut R)
-where
-    A: Aead,
-    A::Key: Random,
-    R: Csprng,
-{
+pub fn test_bad_tag<A: Aead, R: Csprng>(rng: &mut R) {
     let key = A::Key::random(rng);
     let nonce = Nonce::<A::NonceSize>::default();
     assert_all_zero!(nonce);

--- a/crates/crypto/src/test_util/hpke.rs
+++ b/crates/crypto/src/test_util/hpke.rs
@@ -125,10 +125,7 @@ pub use test_hpke;
 
 /// Tests the full encryption-decryption cycle.
 #[allow(non_snake_case)]
-pub fn test_round_trip<K: Kem, F: Kdf, A: Aead + IndCca2, R: Csprng>(rng: &mut R)
-where
-    A::Key: for<'a> Import<&'a [u8]>,
-{
+pub fn test_round_trip<K: Kem, F: Kdf, A: Aead + IndCca2, R: Csprng>(rng: &mut R) {
     const GOLDEN: &[u8] = b"some plaintext";
     const AD: &[u8] = b"some additional data";
     const INFO: &[u8] = b"some contextual binding";

--- a/crates/crypto/src/test_util/hpke.rs
+++ b/crates/crypto/src/test_util/hpke.rs
@@ -11,7 +11,6 @@ use crate::{
     aead::{Aead, IndCca2},
     csprng::{Csprng, Random},
     hpke::{Hpke, Mode, OpenCtx, SealCtx},
-    import::Import,
     kdf::{Expand, Kdf, KdfError, Prk},
     kem::{DecapKey, Kem},
 };

--- a/crates/crypto/src/test_util/mac.rs
+++ b/crates/crypto/src/test_util/mac.rs
@@ -1,7 +1,5 @@
 //! [`Mac`] tests.
 
-use subtle::ConstantTimeEq;
-
 use super::{assert_ct_eq, assert_ct_ne};
 use crate::{
     csprng::{Csprng, Random},

--- a/crates/crypto/src/test_util/mac.rs
+++ b/crates/crypto/src/test_util/mac.rs
@@ -89,12 +89,7 @@ pub use test_mac;
 const DATA: &[u8] = b"hello, world!";
 
 /// Basic positive test.
-pub fn test_default<T, R>(rng: &mut R)
-where
-    T: Mac,
-    T::Key: Random,
-    R: Csprng,
-{
+pub fn test_default<T: Mac, R: Csprng>(rng: &mut R) {
     let key = Random::random(rng);
     let tag1 = T::mac(&key, DATA);
     let tag2 = T::mac(&key, DATA);
@@ -102,12 +97,7 @@ where
 }
 
 /// Tests that [`Mac::update`] is the same as [`Mac::mac`].
-pub fn test_update<T, R>(rng: &mut R)
-where
-    T: Mac,
-    T::Key: Random,
-    R: Csprng,
-{
+pub fn test_update<T: Mac, R: Csprng>(rng: &mut R) {
     let key = Random::random(rng);
     let tag1 = T::mac(&key, DATA);
     let tag2 = {
@@ -121,12 +111,7 @@ where
 }
 
 /// Test [`Mac::verify`].
-pub fn test_verify<T, R>(rng: &mut R)
-where
-    T: Mac,
-    T::Key: Random,
-    R: Csprng,
-{
+pub fn test_verify<T: Mac, R: Csprng>(rng: &mut R) {
     let key = Random::random(rng);
     let tag1 = T::mac(&key, DATA);
 
@@ -138,12 +123,7 @@ where
 }
 
 /// Negative tests for different keys.
-pub fn test_different_keys<T, R>(rng: &mut R)
-where
-    T: Mac,
-    T::Key: ConstantTimeEq + Random,
-    R: Csprng,
-{
+pub fn test_different_keys<T: Mac, R: Csprng>(rng: &mut R) {
     let key1 = Random::random(rng);
     let key2 = Random::random(rng);
     assert_ct_ne!(key1, key2, "keys should differ");
@@ -154,12 +134,7 @@ where
 }
 
 /// Negative test for MACs of different data.
-pub fn test_different_data<T, R>(rng: &mut R)
-where
-    T: Mac,
-    T::Key: Random,
-    R: Csprng,
-{
+pub fn test_different_data<T: Mac, R: Csprng>(rng: &mut R) {
     let key = Random::random(rng);
     let tag1 = T::mac(&key, b"hello");
     let tag2 = T::mac(&key, b"world");

--- a/crates/crypto/src/test_util/mod.rs
+++ b/crates/crypto/src/test_util/mod.rs
@@ -194,6 +194,7 @@ impl<T: Mac> Mac for MacWithDefaults<T> {
     type TagSize = T::TagSize;
 
     type Key = T::Key;
+    type KeySize = T::KeySize;
     type MinKeySize = T::MinKeySize;
 
     fn new(key: &Self::Key) -> Self {

--- a/crates/crypto/src/test_util/mod.rs
+++ b/crates/crypto/src/test_util/mod.rs
@@ -36,7 +36,7 @@ use crate::{
     csprng::{Csprng, Random},
     import::{ExportError, Import, ImportError},
     kdf::{Kdf, KdfError, KdfId, Prk},
-    keys::{FixedLength, InvalidKey, PublicKey, SecretKey},
+    keys::{InvalidKey, PublicKey, SecretKey, SecretKeyBytes},
     mac::{Mac, MacId},
     signer::{Signature, Signer, SignerError, SignerId, SigningKey, VerifyingKey},
 };
@@ -237,14 +237,11 @@ impl<T: Signer + ?Sized> SigningKey<SignerWithDefaults<T>> for SigningKeyWithDef
 }
 
 impl<T: Signer + ?Sized> SecretKey for SigningKeyWithDefaults<T> {
-    type Secret = <T::SigningKey as SecretKey>::Secret;
-    fn try_export_secret(&self) -> Result<Self::Secret, ExportError> {
+    type Size = <T::SigningKey as SecretKey>::Size;
+
+    fn try_export_secret(&self) -> Result<SecretKeyBytes<Self::Size>, ExportError> {
         self.0.try_export_secret()
     }
-}
-
-impl<T: Signer + ?Sized> FixedLength for SigningKeyWithDefaults<T> {
-    type Size = <T::SigningKey as FixedLength>::Size;
 }
 
 impl<T> Random for SigningKeyWithDefaults<T>

--- a/crates/crypto/src/test_util/mod.rs
+++ b/crates/crypto/src/test_util/mod.rs
@@ -36,7 +36,7 @@ use crate::{
     csprng::Csprng,
     import::{ExportError, Import, ImportError},
     kdf::{Kdf, KdfError, KdfId, Prk},
-    keys::{PublicKey, SecretKey, SecretKeyBytes},
+    keys::{PublicKey, SecretKey},
     mac::{Mac, MacId},
     signer::{Signature, Signer, SignerError, SignerId, SigningKey, VerifyingKey},
 };
@@ -240,7 +240,8 @@ impl<T: Signer + ?Sized> SecretKey for SigningKeyWithDefaults<T> {
         Self(T::SigningKey::new(rng))
     }
 
-    fn try_export_secret(&self) -> Result<SecretKeyBytes<Self::Size>, ExportError> {
+    type Secret = <T::SigningKey as SecretKey>::Secret;
+    fn try_export_secret(&self) -> Result<Self::Secret, ExportError> {
         self.0.try_export_secret()
     }
 }

--- a/crates/crypto/src/test_util/signer.rs
+++ b/crates/crypto/src/test_util/signer.rs
@@ -132,10 +132,7 @@ pub fn test_default<T: Signer, R: Csprng>(rng: &mut R) {
 /// Test `Signer::SigningKey::ct_eq`.
 ///
 /// It also tests `Signer::SigningKey::import`.
-pub fn test_sk_ct_eq<T: Signer, R: Csprng>(rng: &mut R)
-where
-    T::SigningKey: for<'a> Import<&'a [u8]>,
-{
+pub fn test_sk_ct_eq<T: Signer, R: Csprng>(rng: &mut R) {
     let sk1 = T::SigningKey::random(rng);
     let sk2 = T::SigningKey::random(rng);
 

--- a/crates/crypto/src/test_util/signer.rs
+++ b/crates/crypto/src/test_util/signer.rs
@@ -8,7 +8,7 @@ use core::borrow::Borrow;
 use super::{assert_ct_eq, assert_ct_ne};
 use crate::{
     csprng::Csprng,
-    keys::SecretKey,
+    keys::{RawSecretBytes, SecretKey},
     signer::{Signer, SigningKey, VerifyingKey},
 };
 
@@ -143,8 +143,8 @@ pub fn test_sk_ct_eq<T: Signer, R: Csprng>(rng: &mut R) {
                 return;
             }
         };
-        let sk1 = K::import(data.as_bytes()).expect("should be able to import key");
-        let sk2 = K::import(data.as_bytes()).expect("should be able to import key");
+        let sk1 = K::import(data.raw_secret_bytes()).expect("should be able to import key");
+        let sk2 = K::import(data.raw_secret_bytes()).expect("should be able to import key");
         assert_ct_eq!(sk1, sk2);
     }
 

--- a/crates/crypto/src/test_util/signer.rs
+++ b/crates/crypto/src/test_util/signer.rs
@@ -7,8 +7,9 @@ use core::borrow::Borrow;
 
 use super::{assert_ct_eq, assert_ct_ne};
 use crate::{
-    csprng::Csprng,
-    keys::{RawSecretBytes, SecretKey},
+    csprng::{Csprng, Random},
+    import::Import,
+    keys::RawSecretBytes,
     signer::{Signer, SigningKey, VerifyingKey},
 };
 
@@ -120,7 +121,7 @@ pub use test_signer;
 /// The base positive test.
 pub fn test_default<T: Signer, R: Csprng>(rng: &mut R) {
     const MSG: &[u8] = b"hello, world!";
-    let sk = T::SigningKey::new(rng);
+    let sk = T::SigningKey::random(rng);
     let sig = sk.sign(MSG).expect("unable to create signature");
     sk.public()
         .expect("signing key should be valid")
@@ -131,11 +132,14 @@ pub fn test_default<T: Signer, R: Csprng>(rng: &mut R) {
 /// Test `Signer::SigningKey::ct_eq`.
 ///
 /// It also tests `Signer::SigningKey::import`.
-pub fn test_sk_ct_eq<T: Signer, R: Csprng>(rng: &mut R) {
-    let sk1 = T::SigningKey::new(rng);
-    let sk2 = T::SigningKey::new(rng);
+pub fn test_sk_ct_eq<T: Signer, R: Csprng>(rng: &mut R)
+where
+    T::SigningKey: for<'a> Import<&'a [u8]>,
+{
+    let sk1 = T::SigningKey::random(rng);
+    let sk2 = T::SigningKey::random(rng);
 
-    fn same_key<T: Signer, K: SigningKey<T>>(k: K) {
+    fn same_key<T: Signer, K: SigningKey<T> + for<'a> Import<&'a [u8]>>(k: K) {
         let data = match k.try_export_secret() {
             Ok(data) => data,
             Err(_) => {
@@ -159,10 +163,10 @@ pub fn test_sk_ct_eq<T: Signer, R: Csprng>(rng: &mut R) {
 ///
 /// It also tests `Signer::VerifyingKey::import`.
 pub fn test_pk_eq<T: Signer, R: Csprng>(rng: &mut R) {
-    let pk1 = T::SigningKey::new(rng)
+    let pk1 = T::SigningKey::random(rng)
         .public()
         .expect("signing key should be valid");
-    let pk2 = T::SigningKey::new(rng)
+    let pk2 = T::SigningKey::random(rng)
         .public()
         .expect("signing key should be valid");
 
@@ -181,7 +185,7 @@ pub fn test_pk_eq<T: Signer, R: Csprng>(rng: &mut R) {
 
 /// [`SigningKey::public`] should always return the same key.
 pub fn test_public<T: Signer, R: Csprng>(rng: &mut R) {
-    let sk = T::SigningKey::new(rng);
+    let sk = T::SigningKey::random(rng);
     assert_eq!(sk.public(), sk.public());
 }
 
@@ -201,7 +205,7 @@ pub fn test_batch_simple_good<T: Signer, R: Csprng>(rng: &mut R) {
     let (pks, sigs): (Vec<_>, Vec<_>) = MSGS
         .iter()
         .map(|msg| {
-            let sk = T::SigningKey::new(rng);
+            let sk = T::SigningKey::random(rng);
             let sig = sk.sign(msg).expect("should not fail");
             (sk.public().expect("signer key should be valid"), sig)
         })
@@ -225,7 +229,7 @@ pub fn test_batch_simple_bad<T: Signer, R: Csprng>(rng: &mut R) {
     let (pks, sigs): (Vec<_>, Vec<_>) = msgs
         .iter()
         .map(|msg| {
-            let sk = T::SigningKey::new(rng);
+            let sk = T::SigningKey::random(rng);
             let sig = sk.sign(msg).expect("should not fail");
             (sk.public().expect("signing key should be valid"), sig)
         })

--- a/crates/crypto/src/test_util/vectors.rs
+++ b/crates/crypto/src/test_util/vectors.rs
@@ -222,18 +222,12 @@ pub mod hpke {
 /// Tests an [`Aead`] against Project Wycheproof test vectors.
 ///
 /// It tests both `A` and [`AeadWithDefaults<T>`].
-pub fn test_aead<A: Aead>(name: AeadTest)
-where
-    A::Key: for<'a> Import<&'a [u8]>,
-{
+pub fn test_aead<A: Aead>(name: AeadTest) {
     test_aead_inner::<A>(name);
     test_aead_inner::<AeadWithDefaults<A>>(name);
 }
 
-fn test_aead_inner<A: Aead>(name: AeadTest)
-where
-    A::Key: for<'a> Import<&'a [u8]>,
-{
+fn test_aead_inner<A: Aead>(name: AeadTest) {
     let set = aead::TestSet::load(name).expect("should be able to load tests");
     for g in &set.test_groups {
         if g.nonce_size / 8 != A::NONCE_SIZE
@@ -310,10 +304,7 @@ where
 
 /// Tests an [`Ecdh`] against Project Wycheproof test
 /// vectors.
-pub fn test_ecdh<T: Ecdh>(name: EcdhTest)
-where
-    T::PrivateKey: for<'a> Import<&'a [u8]>,
-{
+pub fn test_ecdh<T: Ecdh>(name: EcdhTest) {
     let set = ecdh::TestSet::load(name).expect("should be able to load tests");
     for g in &set.test_groups {
         for tc in &g.tests {
@@ -466,11 +457,8 @@ fn test_hkdf_inner<T: Kdf>(name: HkdfTest) {
 pub fn test_hpke<K, F, A>(name: HpkeTest)
 where
     K: Kem,
-    K::DecapKey: for<'a> Import<&'a [u8]>,
-    K::EncapKey: for<'a> Import<&'a [u8]>,
     F: Kdf,
     A: Aead + IndCca2,
-    A::Key: for<'a> Import<&'a [u8]>,
 {
     let set = hpke::TestSet::load(name).expect("should be able to load tests");
     for (i, g) in set.test_groups.iter().enumerate() {
@@ -554,7 +542,7 @@ where
     test_mac_inner::<MacWithDefaults<T>>(name);
 }
 
-fn test_mac_inner<T: Mac>(name: MacTest)
+fn test_mac_inner<T>(name: MacTest)
 where
     T: Mac,
     T::Tag: for<'a> TryFrom<&'a [u8]>,

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -340,6 +340,14 @@ criteria = "safe-to-deploy"
 version = "3.15.0"
 criteria = "safe-to-run"
 
+[[exemptions.thiserror]]
+version = "2.0.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.thiserror-impl]]
+version = "2.0.11"
+criteria = "safe-to-deploy"
+
 [[exemptions.typenum]]
 version = "1.15.0"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Add `Mac::try_new` to support variable length keys. We still keep `Mac::new`, `Mac::Key`, etc. around to support keys stored in HSMs.

I'm not a huge fan of the API, but it's difficult to balance the following:

1. Some MACs only use fixed-length keys (CMAC, ...)
2. Some MACs accept variable length keys (HMAC, KMAC, ...)
3. We need a `type Key` associated type to support keys stored in an HSM.

Ideally, we'd use something like this:

```rust
trait Mac {
    type Key;
}
impl Mac for Kmac {
    type Key = KmacKey;
}
struct KmacKey<'a>(&'a [u8]);
```

But we're missing the lifetime for `type Key = KmacKey`: either `Mac::Key` needs a lifetime or `Kmac` needs a lifetime. The former complicates nearly every use of `Mac::Key` and the latter is simply wrong: `Kmac`'s key only needs to live as long as the call to `<Kmac as Mac>::new`.

It's also complicated by the `for<'a> Import<&'a [u8]>` bound on `SecretKey`. That bound requires the `&[u8]` be valid for *any* lifetime, whereas 

```rust
impl<'a> Import<&'a [u8]> for KmacKey<'a> { ... }
```

requires the `&[u8]` be valid for only `'a`. In other words, the impl isn't general enough to for `KmacKey` to implement `SecretKey`. (We also can't use `struct KmacKey(Vec<u8>)` because we're no-alloc by default.)

I considered removing the `for<'a> Import<&'a [u8]>` bound on `SecretKey`, but it's a particularly invasive change. For example, `hpke::SealCtx::new` requires importing a `SecretKey`. That then bubbles up to other APIs, which will eventually affect `aranya-crypto`.

## Misc

While we're here:

- Move the block size stuff out of `Hash`.
- Clippy was complaining about `<ed25519::SigningKey as ConstantTimeEq>::ct_eq`. Not sure why. It no longer makes a copy of the secret key, which is nice.
- Get rid of `SecretKey::new` in favor of `csprng::Random`.

Fixes #31 