### PR TITLE
crypto: bump to v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "spideroak-crypto"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spideroak-crypto"
 description = "SpiderOak's cryptography library"
-version = "0.4.1"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 license = "BSD-3-Clause"


### PR DESCRIPTION
Includes improvements to the `hex` module, new OIDs, and reverting an accidentally `pub` function.