### PR TITLE
Migrate from `generic-array` to `hybrid-array`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,12 +204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
-name = "const-default"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
-
-[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,18 +413,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
-name = "generic-array"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c8444bc9d71b935156cc0ccab7f622180808af7867b1daae6547d773591703"
-dependencies = [
- "const-default",
- "serde",
- "typenum",
- "zeroize",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +486,7 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "serde",
  "subtle",
  "typenum",
  "zeroize",
@@ -936,8 +919,8 @@ dependencies = [
  "ecdsa",
  "ed25519-dalek",
  "elliptic-curve",
- "generic-array",
  "getrandom 0.4.3",
+ "hybrid-array",
  "more-asserts",
  "p256",
  "p384",

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -90,7 +90,7 @@ rand_compat = [
 serde = [
 	"dep:serde",
 
-	"generic-array/serde",
+	"hybrid-array/serde",
 ]
 
 # Use std.
@@ -170,8 +170,8 @@ der = { version = "0.8", default-features = false }
 ecdsa = { version = "0.17.0", default-features = false, features = ["der"] }
 ed25519-dalek = { version = "3.0.0", default-features = false, features = ["fast", "zeroize"] }
 elliptic-curve = { version = "0.14.1", default-features = false, features = ["ecdh", "arithmetic", "sec1"] }
-generic-array = { version = "1", default-features = false, features = ["const-default", "zeroize"] }
 getrandom = { version = "0.4", default-features = false, optional = true }
+hybrid-array = { version = "0.4.8", default-features = false, features = ["extra-sizes", "zeroize"] }
 more-asserts = { version = "0.3", default-features = false, optional = true }
 p256 = { version = "0.14.0", default-features = false, features = ["ecdh", "ecdsa"] }
 p384 = { version = "0.14.0", default-features = false, features = ["ecdh", "ecdsa"] }
@@ -232,6 +232,3 @@ always_include_features = [
 skip_feature_sets = []
 
 denylist = []
-
-[package.metadata.cargo-machete]
-ignored = ["old-generic-array"]

--- a/crates/crypto/src/aead.rs
+++ b/crates/crypto/src/aead.rs
@@ -13,10 +13,9 @@ use core::{
 };
 
 use buggy::{Bug, BugExt};
-use generic_array::{ArrayLength, GenericArray, IntoArrayLength};
+use hybrid_array::{Array, ArraySize};
 use subtle::{Choice, ConstantTimeEq};
 use typenum::{
-    generic_const_mappings::Const,
     type_operators::{IsGreaterOrEqual, IsLess},
     Unsigned, U16, U65536,
 };
@@ -358,14 +357,14 @@ pub trait Aead {
     /// The size in octets of a key used by this [`Aead`].
     ///
     /// Must be at least 16 octets and less than 2¹⁶ octets.
-    type KeySize: ArrayLength + IsGreaterOrEqual<U16> + IsLess<U65536> + 'static;
+    type KeySize: ArraySize + IsGreaterOrEqual<U16> + IsLess<U65536> + 'static;
     /// Shorthand for [`KeySize`][Self::KeySize].
     const KEY_SIZE: usize = Self::KeySize::USIZE;
 
     /// The size in octets of a nonce used by this [`Aead`].
     ///
     /// Must be less than 2¹⁶ octets.
-    type NonceSize: ArrayLength + IsLess<U65536> + 'static;
+    type NonceSize: ArraySize + IsLess<U65536> + 'static;
     /// Shorthand for [`NonceSize`][Self::NonceSize].
     const NONCE_SIZE: usize = Self::NonceSize::USIZE;
 
@@ -377,7 +376,7 @@ pub trait Aead {
     /// the size of the authentication tag and key commitment.
     ///
     /// Must be at least 16 octets (128 bits).
-    type Overhead: ArrayLength + IsGreaterOrEqual<U16> + 'static;
+    type Overhead: ArraySize + IsGreaterOrEqual<U16> + 'static;
     /// Shorthand for [`Overhead`][Self::Overhead].
     const OVERHEAD: usize = Self::Overhead::USIZE;
 
@@ -536,7 +535,7 @@ pub trait Aead {
 pub type KeyData<A> = SecretKeyBytes<<<A as Aead>::Key as SecretKey>::Size>;
 
 /// An authentication tag.
-pub type Tag<A> = GenericArray<u8, <A as Aead>::Overhead>;
+pub type Tag<A> = Array<u8, <A as Aead>::Overhead>;
 
 const fn check_aead_params<A: Aead + ?Sized>() {
     const {
@@ -676,11 +675,11 @@ raw_key! {
     pub AeadKey,
 }
 
-impl<N: ArrayLength> AeadKey<N> {
+impl<N: ArraySize> AeadKey<N> {
     // Used by `crate::rust::Aes256Gcm::new`.
     pub(crate) fn as_array<const U: usize>(&self) -> &[u8; U]
     where
-        Const<U>: IntoArrayLength<ArrayLength = N>,
+        N: ArraySize<ArrayType<u8> = [u8; U]>,
     {
         self.0.as_array()
     }
@@ -689,9 +688,9 @@ impl<N: ArrayLength> AeadKey<N> {
 /// An [`Aead`] nonce.
 #[derive(Clone, Default, Hash, Eq, PartialEq)]
 #[repr(transparent)]
-pub struct Nonce<N: ArrayLength>(GenericArray<u8, N>);
+pub struct Nonce<N: ArraySize>(Array<u8, N>);
 
-impl<N: ArrayLength> Nonce<N> {
+impl<N: ArraySize> Nonce<N> {
     /// The size in octets of the nonce.
     pub const SIZE: usize = N::USIZE;
 
@@ -704,29 +703,29 @@ impl<N: ArrayLength> Nonce<N> {
 
     // For `aranya-crypto`. Do not use.
     #[doc(hidden)]
-    pub fn into_inner(self) -> GenericArray<u8, N> {
+    pub fn into_inner(self) -> Array<u8, N> {
         self.0
     }
 
-    pub(crate) const fn from_bytes(nonce: GenericArray<u8, N>) -> Self {
+    pub(crate) const fn from_bytes(nonce: Array<u8, N>) -> Self {
         Self(nonce)
     }
 
     pub(crate) fn try_from_slice(data: &[u8]) -> Result<Self, InvalidNonceSize> {
-        let nonce = GenericArray::try_from_slice(data).map_err(|_| InvalidNonceSize)?;
-        Ok(Self(nonce.clone()))
+        let nonce = Array::try_from(data).map_err(|_| InvalidNonceSize)?;
+        Ok(Self(nonce))
     }
 }
 
-impl<N: ArrayLength> Copy for Nonce<N> where N::ArrayType<u8>: Copy {}
+impl<N: ArraySize> Copy for Nonce<N> where N::ArrayType<u8>: Copy {}
 
-impl<N: ArrayLength> Debug for Nonce<N> {
+impl<N: ArraySize> Debug for Nonce<N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Nonce").field(&self.0).finish()
     }
 }
 
-impl<N: ArrayLength> Deref for Nonce<N> {
+impl<N: ArraySize> Deref for Nonce<N> {
     type Target = [u8];
 
     #[inline]
@@ -735,14 +734,14 @@ impl<N: ArrayLength> Deref for Nonce<N> {
     }
 }
 
-impl<N: ArrayLength> DerefMut for Nonce<N> {
+impl<N: ArraySize> DerefMut for Nonce<N> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<N: ArrayLength> BitXor for Nonce<N> {
+impl<N: ArraySize> BitXor for Nonce<N> {
     type Output = Self;
 
     #[inline]
@@ -754,7 +753,7 @@ impl<N: ArrayLength> BitXor for Nonce<N> {
     }
 }
 
-impl<N: ArrayLength> BitXor for &Nonce<N> {
+impl<N: ArraySize> BitXor for &Nonce<N> {
     type Output = Nonce<N>;
 
     #[inline]
@@ -767,20 +766,20 @@ impl<N: ArrayLength> BitXor for &Nonce<N> {
     }
 }
 
-impl<N: ArrayLength> ConstantTimeEq for Nonce<N> {
+impl<N: ArraySize> ConstantTimeEq for Nonce<N> {
     #[inline]
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&other.0)
     }
 }
 
-impl<N: ArrayLength> Random for Nonce<N> {
+impl<N: ArraySize> Random for Nonce<N> {
     fn random<R: Csprng>(rng: R) -> Self {
         Self(Random::random(rng))
     }
 }
 
-impl<N: ArrayLength> Expand for Nonce<N>
+impl<N: ArraySize> Expand for Nonce<N>
 where
     N: IsLess<U65536>,
 {
@@ -796,7 +795,7 @@ where
     }
 }
 
-impl<N: ArrayLength> TryFrom<&[u8]> for Nonce<N> {
+impl<N: ArraySize> TryFrom<&[u8]> for Nonce<N> {
     type Error = InvalidNonceSize;
 
     fn try_from(data: &[u8]) -> Result<Self, InvalidNonceSize> {
@@ -833,7 +832,7 @@ mod committing {
     use core::{fmt, marker::PhantomData, num::NonZeroU64, result::Result};
 
     use buggy::{Bug, BugExt};
-    use generic_array::{ArrayLength, GenericArray};
+    use hybrid_array::{Array, ArraySize};
     use typenum::{
         type_operators::{IsGreaterOrEqual, IsLess},
         Unsigned, U16, U65536,
@@ -846,7 +845,7 @@ mod committing {
     #[doc(hidden)]
     pub trait BlockCipher {
         /// The size in octets of a the cipher's block.
-        type BlockSize: ArrayLength + IsGreaterOrEqual<U16> + IsLess<U65536> + 'static;
+        type BlockSize: ArraySize + IsGreaterOrEqual<U16> + IsLess<U65536> + 'static;
         /// Shorthand for [`BlockSize::USIZE`][Self::BlockSize];
         const BLOCK_SIZE: usize = Self::BlockSize::USIZE;
         /// The cipher's key.
@@ -855,7 +854,7 @@ mod committing {
         /// Creates a new instance of the block cipher.
         fn new(key: &Self::Key) -> Self;
         /// Encrypts `block` in place.
-        fn encrypt_block(&self, block: &mut GenericArray<u8, Self::BlockSize>);
+        fn encrypt_block(&self, block: &mut Array<u8, Self::BlockSize>);
     }
 
     /// An implementation of the Counter-then-Xor (CX) PRF per
@@ -875,7 +874,6 @@ mod committing {
         // The paper requires m < n where m is the nonce space
         // and n is the block size.
         A::NonceSize: IsLess<C::BlockSize>,
-        GenericArray<u8, C::BlockSize>: Clone,
     {
         /// Returns the key commitment and new key (P,L) for
         /// (K,M).
@@ -884,7 +882,7 @@ mod committing {
         pub fn commit(
             key: &A::Key,
             nonce: &Nonce<A::NonceSize>,
-        ) -> Result<(GenericArray<u8, C::BlockSize>, KeyData<A>), Bug> {
+        ) -> Result<(Array<u8, C::BlockSize>, KeyData<A>), Bug> {
             let mut cx = Default::default();
             let key = Self::commit_into(&mut cx, key, nonce)?;
             Ok((cx, key))
@@ -893,7 +891,7 @@ mod committing {
         /// Same as [`commit`][Self::commit], but writes directly
         /// to `cx`.
         pub fn commit_into(
-            cx: &mut GenericArray<u8, C::BlockSize>,
+            cx: &mut Array<u8, C::BlockSize>,
             key: &A::Key,
             nonce: &Nonce<A::NonceSize>,
         ) -> Result<KeyData<A>, Bug> {
@@ -907,12 +905,12 @@ mod committing {
             fn pad<C: BlockCipher>(
                 m: &[u8],
                 i: NonZeroU64,
-            ) -> Result<GenericArray<u8, C::BlockSize>, Bug> {
+            ) -> Result<Array<u8, C::BlockSize>, Bug> {
                 // This is checked by `Self`'s generic bounds, but it
                 // doesn't hurt to double check.
                 debug_assert!(m.len() < C::BlockSize::USIZE);
 
-                let mut b = GenericArray::<u8, C::BlockSize>::default();
+                let mut b = Array::<u8, C::BlockSize>::default();
                 b[..m.len()].copy_from_slice(m);
                 let x = i.get().to_le_bytes();
                 let n = usize::checked_sub(b.len(), m.len())
@@ -1365,7 +1363,7 @@ mod committing {
                         hmac.update(ad);
                         hmac.tag()
                     };
-                    let mut key_bytes = $crate::generic_array::GenericArray::<
+                    let mut key_bytes = $crate::hybrid_array::Array::<
                         u8,
                         <<$inner as $crate::aead::Aead>::Key as $crate::keys::SecretKey>::Size,
                     >::default();

--- a/crates/crypto/src/block.rs
+++ b/crates/crypto/src/block.rs
@@ -2,7 +2,7 @@
 
 #![forbid(unsafe_code)]
 
-use generic_array::{ArrayLength, GenericArray};
+use hybrid_array::{Array, ArraySize};
 
 /// Implemented by types that operate on blocks.
 ///
@@ -10,8 +10,8 @@ use generic_array::{ArrayLength, GenericArray};
 /// construction.
 pub trait BlockSize {
     /// The size in bytes of the block.
-    type BlockSize: ArrayLength;
+    type BlockSize: ArraySize;
 }
 
 /// A block.
-pub type Block<S> = GenericArray<u8, <S as BlockSize>::BlockSize>;
+pub type Block<S> = Array<u8, <S as BlockSize>::BlockSize>;

--- a/crates/crypto/src/csprng.rs
+++ b/crates/crypto/src/csprng.rs
@@ -3,9 +3,9 @@
 #[cfg(feature = "alloc")]
 use alloc::{boxed::Box, rc::Rc, sync::Arc};
 
-use generic_array::{ArrayLength, GenericArray};
 #[cfg(all(feature = "getrandom", not(target_os = "vxworks")))]
 pub use getrandom;
+use hybrid_array::{Array, ArraySize};
 #[cfg(feature = "rand_compat")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rand_compat")))]
 pub use rand;
@@ -106,7 +106,7 @@ pub trait Random {
     fn random<R: Csprng>(rng: R) -> Self;
 }
 
-impl<N: ArrayLength> Random for GenericArray<u8, N> {
+impl<N: ArraySize> Random for Array<u8, N> {
     fn random<R: Csprng>(rng: R) -> Self {
         let mut v = Self::default();
         rng.fill_bytes(&mut v);

--- a/crates/crypto/src/ec.rs
+++ b/crates/crypto/src/ec.rs
@@ -6,9 +6,9 @@ use core::{
     ops::Shl,
 };
 
-use generic_array::{ArrayLength, GenericArray, IntoArrayLength};
+use hybrid_array::{Array, ArraySize};
 use subtle::{Choice, ConstantTimeEq};
-use typenum::{Const, Double, Unsigned, B1, U133, U32, U33, U48, U49, U65, U66, U67, U97};
+use typenum::{Double, Unsigned, B1, U133, U32, U33, U48, U49, U65, U66, U67, U97};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{
@@ -20,15 +20,15 @@ use crate::{
 // `Compressed`, and `Scalar`?
 
 /// An elliptic curve.
-pub trait Curve: Copy + Clone + Eq + PartialEq {
+pub trait Curve: Copy + Eq {
     /// The size in bytes of a scalar.
-    type ScalarSize: ArrayLength + Unsigned + Copy + Clone + Eq + PartialEq;
+    type ScalarSize: ArraySize + Eq;
 
     /// The size in bytes of a compressed point.
-    type CompressedSize: ArrayLength + Unsigned + Copy + Clone + Eq + PartialEq;
+    type CompressedSize: ArraySize + Eq;
 
     /// The size in bytes of a uncompressed point.
-    type UncompressedSize: ArrayLength + Unsigned + Copy + Clone + Eq + PartialEq;
+    type UncompressedSize: ArraySize + Eq;
 }
 
 macro_rules! curve_impl {
@@ -61,7 +61,7 @@ macro_rules! pk_impl {
         #[doc = "This is equivalent to X9.62 encoding.\n\n"]
         #[doc = "[SEC]: https://www.secg.org/sec1-v2.pdf"]
         #[derive(Clone, Default, Eq, PartialEq, Zeroize)]
-        pub struct $name<C: Curve>(pub GenericArray<u8, C::$size>);
+        pub struct $name<C: Curve>(pub Array<u8, C::$size>);
 
         impl<C: Curve> $name<C> {
             /// Returns a raw pointer to the point.
@@ -81,7 +81,7 @@ macro_rules! pk_impl {
             }
         }
 
-        impl<C: Curve> Copy for $name<C> where <C::$size as ArrayLength>::ArrayType<u8>: Copy {}
+        impl<C: Curve> Copy for $name<C> where <C::$size as ArraySize>::ArrayType<u8>: Copy {}
 
         impl<C: Curve> AsRef<[u8]> for $name<C> {
             #[inline]
@@ -113,7 +113,7 @@ macro_rules! pk_impl {
 
         impl<C: Curve, const N: usize> From<$name<C>> for [u8; N]
         where
-            [u8; N]: From<GenericArray<u8, C::$size>>,
+            [u8; N]: From<Array<u8, C::$size>>,
         {
             fn from(v: $name<C>) -> Self {
                 v.0.into()
@@ -122,7 +122,7 @@ macro_rules! pk_impl {
 
         impl<C: Curve, const N: usize> From<[u8; N]> for $name<C>
         where
-            GenericArray<u8, C::$size>: From<[u8; N]>,
+            Array<u8, C::$size>: From<[u8; N]>,
         {
             fn from(data: [u8; N]) -> Self {
                 Self(data.into())
@@ -133,7 +133,7 @@ macro_rules! pk_impl {
             type Error = InvalidSizeError;
 
             fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
-                let v: &GenericArray<u8, _> = data.try_into().map_err(|_| InvalidSizeError {
+                let v: &Array<u8, _> = data.try_into().map_err(|_| InvalidSizeError {
                     got: data.len(),
                     want: C::$size::USIZE..C::$size::USIZE,
                 })?;
@@ -143,7 +143,7 @@ macro_rules! pk_impl {
 
         impl<C: Curve, const N: usize> Import<[u8; N]> for $name<C>
         where
-            GenericArray<u8, C::$size>: From<[u8; N]>,
+            Array<u8, C::$size>: From<[u8; N]>,
         {
             fn import(data: [u8; N]) -> Result<Self, ImportError> {
                 Ok(Self::from(data))
@@ -158,8 +158,8 @@ macro_rules! pk_impl {
 
         impl<C: Curve> fmt::Debug for $name<C>
         where
-            <C as Curve>::$size: ArrayLength + Shl<B1>,
-            Double<C::$size>: ArrayLength,
+            <C as Curve>::$size: ArraySize + Shl<B1>,
+            Double<C::$size>: ArraySize,
         {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_tuple(stringify!($name))
@@ -174,7 +174,7 @@ pk_impl!(Uncompressed, UncompressedSize);
 
 /// An elliptic curve scalar.
 #[derive(Default, ZeroizeOnDrop)]
-pub struct Scalar<C: Curve>(pub GenericArray<u8, C::ScalarSize>);
+pub struct Scalar<C: Curve>(pub Array<u8, C::ScalarSize>);
 
 impl<C: Curve> Scalar<C> {
     /// Returns a raw pointer to the scalar.
@@ -194,10 +194,7 @@ impl<C: Curve> Scalar<C> {
     }
 }
 
-impl<C: Curve> Clone for Scalar<C>
-where
-    <C::ScalarSize as ArrayLength>::ArrayType<u8>: Clone,
-{
+impl<C: Curve> Clone for Scalar<C> {
     fn clone(&self) -> Self {
         Self(self.0.clone())
     }
@@ -240,7 +237,7 @@ impl<C: Curve> BorrowMut<[u8]> for Scalar<C> {
 
 impl<C: Curve, const N: usize> From<Scalar<C>> for [u8; N]
 where
-    [u8; N]: From<GenericArray<u8, C::ScalarSize>>,
+    [u8; N]: From<Array<u8, C::ScalarSize>>,
 {
     fn from(v: Scalar<C>) -> Self {
         v.0.clone().into()
@@ -249,8 +246,7 @@ where
 
 impl<C: Curve, const N: usize> From<[u8; N]> for Scalar<C>
 where
-    Const<N>: IntoArrayLength,
-    GenericArray<u8, C::ScalarSize>: From<[u8; N]>,
+    Array<u8, C::ScalarSize>: From<[u8; N]>,
 {
     fn from(v: [u8; N]) -> Self {
         Self(v.into())
@@ -261,19 +257,17 @@ impl<C: Curve> TryFrom<&[u8]> for Scalar<C> {
     type Error = InvalidSizeError;
 
     fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
-        let v: &GenericArray<u8, _> = data.try_into().map_err(|_| InvalidSizeError {
+        let v: Array<u8, _> = data.try_into().map_err(|_| InvalidSizeError {
             got: data.len(),
             want: C::ScalarSize::USIZE..C::ScalarSize::USIZE,
         })?;
-        Ok(Self(v.clone()))
+        Ok(Self(v))
     }
 }
 
 impl<C: Curve, const N: usize> Import<[u8; N]> for Scalar<C>
 where
-    C::ScalarSize: ArrayLength,
-    Const<N>: IntoArrayLength,
-    GenericArray<u8, C::ScalarSize>: From<[u8; N]>,
+    Array<u8, C::ScalarSize>: From<[u8; N]>,
 {
     fn import(data: [u8; N]) -> Result<Self, ImportError> {
         Ok(Self::from(data))

--- a/crates/crypto/src/hash.rs
+++ b/crates/crypto/src/hash.rs
@@ -7,11 +7,10 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
-use generic_array::{ArrayLength, GenericArray, IntoArrayLength};
+use hybrid_array::{Array, ArraySize};
 use sha3_utils::{encode_string, right_encode_bytes};
 use subtle::{Choice, ConstantTimeEq};
 use typenum::{
-    generic_const_mappings::Const,
     type_operators::{IsGreaterOrEqual, IsLess},
     Unsigned, U32, U65536,
 };
@@ -35,7 +34,7 @@ pub trait Hash: Clone {
     /// The size in octets of a digest used by this [`Hash`].
     ///
     /// Must be at least 32 octets and less than 2¹⁶ octets.
-    type DigestSize: ArrayLength + IsGreaterOrEqual<U32> + IsLess<U65536> + 'static;
+    type DigestSize: ArraySize + IsGreaterOrEqual<U32> + IsLess<U65536> + 'static;
     /// Shorthand for [`DigestSize`][Self::DigestSize].
     const DIGEST_SIZE: usize = Self::DigestSize::USIZE;
 
@@ -66,12 +65,12 @@ pub trait Hash: Clone {
 /// The output of a [`Hash`].
 #[derive(Clone, Default)]
 #[repr(transparent)]
-pub struct Digest<N: ArrayLength>(GenericArray<u8, N>);
+pub struct Digest<N: ArraySize>(Array<u8, N>);
 
-impl<N: ArrayLength> Digest<N> {
+impl<N: ArraySize> Digest<N> {
     /// Creates a new hash digest.
     #[inline]
-    pub const fn new(digest: GenericArray<u8, N>) -> Self {
+    pub const fn new(digest: Array<u8, N>) -> Self {
         Self(digest)
     }
 
@@ -79,9 +78,9 @@ impl<N: ArrayLength> Digest<N> {
     #[inline]
     pub const fn from_array<const U: usize>(digest: [u8; U]) -> Self
     where
-        Const<U>: IntoArrayLength<ArrayLength = N>,
+        N: ArraySize<ArrayType<u8> = [u8; U]>,
     {
-        Self::new(GenericArray::from_array(digest))
+        Self::new(Array(digest))
     }
 
     /// Returns the length of the hash digest.
@@ -105,14 +104,14 @@ impl<N: ArrayLength> Digest<N> {
 
     /// Converts itself to an array.
     #[inline]
-    pub fn into_array(self) -> GenericArray<u8, N> {
+    pub fn into_array(self) -> Array<u8, N> {
         self.0
     }
 }
 
-impl<N: ArrayLength> Copy for Digest<N> where N::ArrayType<u8>: Copy {}
+impl<N: ArraySize> Copy for Digest<N> where N::ArrayType<u8>: Copy {}
 
-impl<N: ArrayLength> Deref for Digest<N> {
+impl<N: ArraySize> Deref for Digest<N> {
     type Target = [u8];
 
     #[inline]
@@ -121,14 +120,14 @@ impl<N: ArrayLength> Deref for Digest<N> {
     }
 }
 
-impl<N: ArrayLength> DerefMut for Digest<N> {
+impl<N: ArraySize> DerefMut for Digest<N> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<N: ArrayLength> Debug for Digest<N> {
+impl<N: ArraySize> Debug for Digest<N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Digest").field(&self.0).finish()
     }
@@ -137,12 +136,12 @@ impl<N: ArrayLength> Debug for Digest<N> {
 // Gated for safety purposes; see the comment inside
 // `PartialEq::Eq`.
 #[cfg(any(test, feature = "test_util"))]
-impl<N: ArrayLength> Eq for Digest<N> {}
+impl<N: ArraySize> Eq for Digest<N> {}
 
 // Gated for safety purposes; see the comment inside
 // `PartialEq::Eq`.
 #[cfg(any(test, feature = "test_util"))]
-impl<N: ArrayLength> PartialEq for Digest<N> {
+impl<N: ArraySize> PartialEq for Digest<N> {
     fn eq(&self, other: &Self) -> bool {
         // While it's generally fine to compare digests with ==
         // (non-constant time), it has the potential to be
@@ -159,7 +158,7 @@ impl<N: ArrayLength> PartialEq for Digest<N> {
     }
 }
 
-impl<N: ArrayLength> ConstantTimeEq for Digest<N> {
+impl<N: ArraySize> ConstantTimeEq for Digest<N> {
     #[inline]
     fn ct_eq(&self, other: &Self) -> Choice {
         self.as_bytes().ct_eq(other.as_bytes())

--- a/crates/crypto/src/hkdf.rs
+++ b/crates/crypto/src/hkdf.rs
@@ -6,7 +6,7 @@
 
 use core::{fmt, marker::PhantomData};
 
-use generic_array::GenericArray;
+use hybrid_array::Array;
 use typenum::{Prod, U255};
 
 use crate::{
@@ -57,7 +57,7 @@ impl<H: Hash + BlockSize> Hkdf<H> {
         // if not provided, it is set to a string of HashLen
         // zeros.
         let salt = if salt.is_empty() {
-            let zero = GenericArray::<u8, H::DigestSize>::default();
+            let zero = Array::<u8, H::DigestSize>::default();
             HmacKey::new(zero.as_slice())
         } else {
             HmacKey::new(salt)

--- a/crates/crypto/src/hmac.rs
+++ b/crates/crypto/src/hmac.rs
@@ -4,9 +4,9 @@
 
 #![forbid(unsafe_code)]
 
-use core::{cmp, fmt};
+use core::{array::TryFromSliceError, cmp, fmt};
 
-use generic_array::{ArrayLength, GenericArray, LengthError};
+use hybrid_array::{Array, ArraySize};
 use subtle::{Choice, ConstantTimeEq};
 use zeroize::{ZeroizeOnDrop, Zeroizing};
 
@@ -84,9 +84,9 @@ impl<H: Hash + BlockSize> Hmac<H> {
 /// An [`Hmac`] authentication code.
 #[derive(Clone, Debug)]
 #[repr(transparent)]
-pub struct Tag<N: ArrayLength>(Digest<N>);
+pub struct Tag<N: ArraySize>(Digest<N>);
 
-impl<N: ArrayLength> Tag<N> {
+impl<N: ArraySize> Tag<N> {
     /// Returns the size in bytes of the tag.
     #[cfg(feature = "committing-aead")]
     #[cfg_attr(docsrs, doc(cfg(feature = "committing-aead")))]
@@ -100,7 +100,7 @@ impl<N: ArrayLength> Tag<N> {
     // needed by the `hkdf` module and `aranya-crypto` crates,
     // however.
     #[doc(hidden)]
-    pub fn into_array(self) -> GenericArray<u8, N> {
+    pub fn into_array(self) -> Array<u8, N> {
         self.0.into_array()
     }
 }
@@ -110,7 +110,7 @@ impl<N: ArrayLength> Tag<N> {
 // `ConstantTimeEq`. It's needed by the `hkdf` module, however.
 cfg_if::cfg_if! {
     if #[cfg(feature = "hazmat")] {
-        impl<N: ArrayLength> Tag<N> {
+        impl<N: ArraySize> Tag<N> {
             /// Returns the tag as a byte slice.
             ///
             /// # ⚠️ Warning
@@ -125,7 +125,7 @@ cfg_if::cfg_if! {
             }
         }
     } else {
-        impl<N: ArrayLength> Tag<N> {
+        impl<N: ArraySize> Tag<N> {
             pub(crate) const fn as_bytes(&self) -> &[u8] {
                 self.0.as_bytes()
             }
@@ -133,7 +133,7 @@ cfg_if::cfg_if! {
     }
 }
 
-impl<N: ArrayLength> ConstantTimeEq for Tag<N> {
+impl<N: ArraySize> ConstantTimeEq for Tag<N> {
     #[inline]
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&other.0)
@@ -141,12 +141,12 @@ impl<N: ArrayLength> ConstantTimeEq for Tag<N> {
 }
 
 // Required by `crate::test_util::test_mac`.
-impl<'a, N: ArrayLength> TryFrom<&'a [u8]> for Tag<N> {
-    type Error = LengthError;
+impl<'a, N: ArraySize> TryFrom<&'a [u8]> for Tag<N> {
+    type Error = TryFromSliceError;
 
     fn try_from(tag: &'a [u8]) -> Result<Self, Self::Error> {
-        let digest = GenericArray::try_from_slice(tag)?;
-        Ok(Self(Digest::new(digest.clone())))
+        let digest = Array::try_from(tag)?;
+        Ok(Self(Digest::new(digest)))
     }
 }
 

--- a/crates/crypto/src/hpke.rs
+++ b/crates/crypto/src/hpke.rs
@@ -18,7 +18,7 @@
 use core::{fmt, iter, marker::PhantomData, num::NonZeroU16, result::Result};
 
 use buggy::{bug, Bug, BugExt};
-use generic_array::ArrayLength;
+use hybrid_array::ArraySize;
 use subtle::{Choice, ConstantTimeEq};
 use typenum::Unsigned as _;
 
@@ -39,7 +39,7 @@ macro_rules! i2osp {
     };
     ($v:expr, $n:ty) => {{
         let src = $v.to_be_bytes();
-        let mut dst = generic_array::GenericArray::<u8, $n>::default();
+        let mut dst = hybrid_array::Array::<u8, $n>::default();
         // Copy `src` into `dst`, padding with zeros on the
         // left.
         //
@@ -1176,7 +1176,7 @@ impl Seq {
     ///
     /// Exported for `aranya-crypto`. Do not use.
     #[doc(hidden)]
-    pub const fn max<N: ArrayLength>() -> u64 {
+    pub const fn max<N: ArraySize>() -> u64 {
         // 1<<(8*N) - 1
         let shift = 8usize.saturating_mul(N::USIZE);
         match 1u64.checked_shl(shift as u32) {
@@ -1187,7 +1187,7 @@ impl Seq {
 
     /// Increments the sequence by one and returns the *previous*
     /// sequence number.
-    fn increment<N: ArrayLength>(&mut self) -> Result<Self, Bug> {
+    fn increment<N: ArraySize>(&mut self) -> Result<Self, Bug> {
         // if self.seq >= (1 << (8*Nn)) - 1:
         //     raise MessageLimitReachedError
         if self.seq >= Self::max::<N>() {
@@ -1204,7 +1204,7 @@ impl Seq {
     }
 
     /// Computes the per-message nonce.
-    fn compute_nonce<N: ArrayLength>(
+    fn compute_nonce<N: ArraySize>(
         self,
         base_nonce: &Nonce<N>,
     ) -> Result<Nonce<N>, MessageLimitReached> {

--- a/crates/crypto/src/import.rs
+++ b/crates/crypto/src/import.rs
@@ -7,7 +7,7 @@ use core::{
 };
 
 use buggy::Bug;
-use generic_array::{ArrayLength, GenericArray};
+use hybrid_array::{Array, ArraySize};
 
 use crate::signer::PkError;
 
@@ -134,9 +134,9 @@ impl<const N: usize> Import<[u8; N]> for [u8; N] {
     }
 }
 
-impl<'a, N: ArrayLength> Import<&'a [u8]> for &'a GenericArray<u8, N> {
+impl<'a, N: ArraySize> Import<&'a [u8]> for &'a Array<u8, N> {
     fn import(data: &'a [u8]) -> Result<Self, ImportError> {
-        GenericArray::try_from_slice(data).map_err(|_| {
+        data.try_into().map_err(|_| {
             ImportError::InvalidSize(InvalidSizeError {
                 got: data.len(),
                 want: N::USIZE..N::USIZE,
@@ -145,16 +145,16 @@ impl<'a, N: ArrayLength> Import<&'a [u8]> for &'a GenericArray<u8, N> {
     }
 }
 
-impl<N: ArrayLength> Import<&[u8]> for GenericArray<u8, N> {
+impl<N: ArraySize> Import<&[u8]> for Array<u8, N> {
     fn import(data: &[u8]) -> Result<Self, ImportError> {
-        let data: &GenericArray<u8, N> = Import::<_>::import(data)?;
+        let data: &Array<u8, N> = Import::<_>::import(data)?;
         Ok(data.clone())
     }
 }
 
-impl<N: ArrayLength> Import<GenericArray<u8, N>> for GenericArray<u8, N> {
+impl<N: ArraySize> Import<Array<u8, N>> for Array<u8, N> {
     #[inline]
-    fn import(data: GenericArray<u8, N>) -> Result<Self, ImportError> {
+    fn import(data: Array<u8, N>) -> Result<Self, ImportError> {
         Ok(data)
     }
 }

--- a/crates/crypto/src/kdf.rs
+++ b/crates/crypto/src/kdf.rs
@@ -5,11 +5,11 @@
 use core::{fmt, iter::IntoIterator, mem, result::Result};
 
 use buggy::Bug;
-use generic_array::{ArrayLength, ConstArrayLength, GenericArray, IntoArrayLength};
+use hybrid_array::{Array, ArraySize};
 use subtle::{Choice, ConstantTimeEq};
 use typenum::{
     type_operators::{IsGreaterOrEqual, IsLess},
-    Const, Unsigned, U32, U64, U65536,
+    Const, ToUInt, Unsigned, U, U32, U64, U65536,
 };
 use zeroize::ZeroizeOnDrop;
 
@@ -72,7 +72,7 @@ pub trait Kdf {
     /// [`extract_and_expand`][Self::extract_and_expand].
     ///
     /// Must be at least 64 octets (512 bits).
-    type MaxOutput: ArrayLength + IsGreaterOrEqual<U64> + 'static;
+    type MaxOutput: ArraySize + IsGreaterOrEqual<U64> + 'static;
     /// The size in octets of the largest key that can be created
     /// with [`expand`][Self::expand],
     /// [`expand_multi`][Self::expand_multi], or
@@ -85,7 +85,7 @@ pub trait Kdf {
     /// [`Kdf`].
     ///
     /// Must be at least 32 octets and less than 2¹⁶ octets.
-    type PrkSize: ArrayLength + IsGreaterOrEqual<U32> + IsLess<U65536> + 'static;
+    type PrkSize: ArraySize + IsGreaterOrEqual<U32> + IsLess<U65536> + 'static;
     /// Shorthand for [`PrkSize`][Self::PrkSize].
     const PRK_SIZE: usize = Self::PrkSize::USIZE;
 
@@ -194,9 +194,9 @@ pub trait Kdf {
 /// A pseudorandom key.
 #[derive(Clone, Default, ZeroizeOnDrop)]
 #[repr(transparent)]
-pub struct Prk<N: ArrayLength>(SecretKeyBytes<N>);
+pub struct Prk<N: ArraySize>(SecretKeyBytes<N>);
 
-impl<N: ArrayLength> Prk<N> {
+impl<N: ArraySize> Prk<N> {
     /// Creates a new PRK.
     #[inline]
     pub const fn new(prk: SecretKeyBytes<N>) -> Self {
@@ -232,21 +232,21 @@ impl<N: ArrayLength> Prk<N> {
     }
 }
 
-impl<N: ArrayLength> ConstantTimeEq for Prk<N> {
+impl<N: ArraySize> ConstantTimeEq for Prk<N> {
     #[inline]
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&other.0)
     }
 }
 
-impl<N: ArrayLength> RawSecretBytes for Prk<N> {
+impl<N: ArraySize> RawSecretBytes for Prk<N> {
     #[inline]
     fn raw_secret_bytes(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl<N: ArrayLength> Expand for Prk<N>
+impl<N: ArraySize> Expand for Prk<N>
 where
     N: IsLess<U65536>,
 {
@@ -262,7 +262,7 @@ where
     }
 }
 
-impl<N: ArrayLength> fmt::Debug for Prk<N> {
+impl<N: ArraySize> fmt::Debug for Prk<N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Prk").finish_non_exhaustive()
     }
@@ -271,7 +271,7 @@ impl<N: ArrayLength> fmt::Debug for Prk<N> {
 /// Implemented by types that can expand themselves from a PRK.
 pub trait Expand: Sized {
     /// The size in octets of the derived key.
-    type Size: ArrayLength + IsLess<U65536> + 'static;
+    type Size: ArraySize + IsLess<U65536> + 'static;
 
     /// Derives itself from a PRK.
     fn expand<K: Kdf>(prk: &Prk<K::PrkSize>, info: &[u8]) -> Result<Self, KdfError> {
@@ -285,7 +285,7 @@ pub trait Expand: Sized {
         I: IntoIterator<Item = &'a [u8], IntoIter: Clone>;
 }
 
-impl<N: ArrayLength> Expand for GenericArray<u8, N>
+impl<N: ArraySize> Expand for Array<u8, N>
 where
     N: IsLess<U65536>,
 {
@@ -297,7 +297,7 @@ where
         I: IntoIterator<Item = &'a [u8]>,
         I::IntoIter: Clone,
     {
-        let mut out = GenericArray::default();
+        let mut out = Array::default();
         K::expand_multi(&mut out, prk, info)?;
         Ok(out)
     }
@@ -305,10 +305,10 @@ where
 
 impl<const N: usize> Expand for [u8; N]
 where
-    Const<N>: IntoArrayLength,
-    ConstArrayLength<N>: IsLess<U65536>,
+    Const<N>: ToUInt,
+    U<N>: IsLess<U65536> + ArraySize,
 {
-    type Size = ConstArrayLength<N>;
+    type Size = U<N>;
 
     fn expand_multi<'a, K, I>(prk: &Prk<K::PrkSize>, info: I) -> Result<Self, KdfError>
     where

--- a/crates/crypto/src/keys.rs
+++ b/crates/crypto/src/keys.rs
@@ -2,9 +2,9 @@
 
 use core::{borrow::Borrow, fmt, iter::IntoIterator, mem, result::Result};
 
-use generic_array::{ArrayLength, GenericArray, IntoArrayLength};
+use hybrid_array::{Array, ArraySize};
 use subtle::{Choice, ConstantTimeEq};
-use typenum::{generic_const_mappings::Const, IsLess, U65536};
+use typenum::{IsLess, U65536};
 use zeroize::ZeroizeOnDrop;
 
 use crate::{
@@ -21,7 +21,7 @@ pub trait SecretKey:
     Clone + ConstantTimeEq + for<'a> Import<&'a [u8]> + Random + ZeroizeOnDrop
 {
     /// The size in octets of the key.
-    type Size: ArrayLength + 'static;
+    type Size: ArraySize + 'static;
 
     /// Attempts to export the key's secret data.
     fn try_export_secret(&self) -> Result<SecretKeyBytes<Self::Size>, ExportError>;
@@ -50,21 +50,21 @@ impl RawSecretBytes for [u8] {
 /// A fixed-length byte encoding of a [`SecretKey`]'s data.
 #[derive(Clone, Default, ZeroizeOnDrop)]
 #[repr(transparent)]
-pub struct SecretKeyBytes<N: ArrayLength>(GenericArray<u8, N>);
+pub struct SecretKeyBytes<N: ArraySize>(Array<u8, N>);
 
-impl<N: ArrayLength> fmt::Debug for SecretKeyBytes<N> {
+impl<N: ArraySize> fmt::Debug for SecretKeyBytes<N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SecretKeyBytes").finish_non_exhaustive()
     }
 }
 
-impl<N: ArrayLength> SecretKeyBytes<N> {
+impl<N: ArraySize> SecretKeyBytes<N> {
     /// The size in bytes of the secret key.
     pub const SIZE: usize = N::USIZE;
 
     /// Creates a new secret.
     #[inline]
-    pub const fn new(secret: GenericArray<u8, N>) -> Self {
+    pub const fn new(secret: Array<u8, N>) -> Self {
         Self(secret)
     }
 
@@ -78,9 +78,9 @@ impl<N: ArrayLength> SecretKeyBytes<N> {
     /// Returns a reference to the secret key bytes as an array.
     pub(crate) fn as_array<const U: usize>(&self) -> &[u8; U]
     where
-        Const<U>: IntoArrayLength<ArrayLength = N>,
+        N: ArraySize<ArrayType<u8> = [u8; U]>,
     {
-        self.0.as_ref()
+        &(self.0).0
     }
 
     /// Returns the secret key bytes as a byte slice.
@@ -96,7 +96,7 @@ impl<N: ArrayLength> SecretKeyBytes<N> {
 
     /// Converts the secret key bytes to an array.
     #[inline]
-    pub fn into_bytes(mut self) -> GenericArray<u8, N> {
+    pub fn into_bytes(mut self) -> Array<u8, N> {
         // This is fine since we're consuming the receiver. If
         // the receiver were an exclusive reference this would be
         // very wrong since it'd be replacing the secret key with
@@ -105,20 +105,20 @@ impl<N: ArrayLength> SecretKeyBytes<N> {
     }
 }
 
-impl<N: ArrayLength> ConstantTimeEq for SecretKeyBytes<N> {
+impl<N: ArraySize> ConstantTimeEq for SecretKeyBytes<N> {
     #[inline]
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&other.0)
     }
 }
 
-impl<N: ArrayLength> Random for SecretKeyBytes<N> {
+impl<N: ArraySize> Random for SecretKeyBytes<N> {
     fn random<R: Csprng>(rng: R) -> Self {
         Self(Random::random(rng))
     }
 }
 
-impl<N: ArrayLength> Expand for SecretKeyBytes<N>
+impl<N: ArraySize> Expand for SecretKeyBytes<N>
 where
     N: IsLess<U65536>,
 {
@@ -134,7 +134,7 @@ where
     }
 }
 
-impl<N: ArrayLength> RawSecretBytes for SecretKeyBytes<N> {
+impl<N: ArraySize> RawSecretBytes for SecretKeyBytes<N> {
     #[inline]
     fn raw_secret_bytes(&self) -> &[u8] {
         self.as_bytes()
@@ -180,9 +180,9 @@ macro_rules! raw_key {
         $(#[$meta])*
         #[derive(::core::clone::Clone, $crate::zeroize::ZeroizeOnDrop)]
         #[repr(transparent)]
-        $vis struct $name<N: $crate::generic_array::ArrayLength>($crate::keys::SecretKeyBytes<N>);
+        $vis struct $name<N: $crate::hybrid_array::ArraySize>($crate::keys::SecretKeyBytes<N>);
 
-        impl<N: ::generic_array::ArrayLength> $name<N> {
+        impl<N: ::hybrid_array::ArraySize> $name<N> {
             /// Creates a new raw key.
             #[inline]
             pub const fn new(key: $crate::keys::SecretKeyBytes<N>) -> Self {
@@ -221,7 +221,7 @@ macro_rules! raw_key {
             }
         }
 
-        impl<N: $crate::generic_array::ArrayLength> $crate::keys::SecretKey for $name<N> {
+        impl<N: $crate::hybrid_array::ArraySize> $crate::keys::SecretKey for $name<N> {
             type Size = N;
 
             #[inline]
@@ -233,21 +233,21 @@ macro_rules! raw_key {
             }
         }
 
-        impl<N: $crate::generic_array::ArrayLength> $crate::csprng::Random for $name<N> {
+        impl<N: $crate::hybrid_array::ArraySize> $crate::csprng::Random for $name<N> {
             fn random<R: $crate::csprng::Csprng>(rng: R) -> Self {
                 let sk = <$crate::keys::SecretKeyBytes<N> as $crate::csprng::Random>::random(rng);
                 Self(sk)
             }
         }
 
-        impl<N: $crate::generic_array::ArrayLength> $crate::keys::RawSecretBytes for $name<N> {
+        impl<N: $crate::hybrid_array::ArraySize> $crate::keys::RawSecretBytes for $name<N> {
             #[inline]
             fn raw_secret_bytes(&self) -> &[u8] {
                 $crate::keys::RawSecretBytes::raw_secret_bytes(&self.0)
             }
         }
 
-        impl<N: $crate::generic_array::ArrayLength> $crate::kdf::Expand for $name<N>
+        impl<N: $crate::hybrid_array::ArraySize> $crate::kdf::Expand for $name<N>
         where
             N: ::typenum::IsLess<::typenum::U65536>
         {
@@ -266,7 +266,7 @@ macro_rules! raw_key {
             }
         }
 
-        impl<N: $crate::generic_array::ArrayLength> ::subtle::ConstantTimeEq for $name<N> {
+        impl<N: $crate::hybrid_array::ArraySize> ::subtle::ConstantTimeEq for $name<N> {
             #[inline]
             fn ct_eq(&self, other: &Self) -> ::subtle::Choice {
                 self.0.ct_eq(&other.0)
@@ -275,17 +275,16 @@ macro_rules! raw_key {
 
         impl<N, const U: usize> $crate::import::Import<[u8; U]> for $name<N>
         where
-            N: $crate::generic_array::ArrayLength,
-            ::typenum::generic_const_mappings::Const<U>: $crate::generic_array::IntoArrayLength<ArrayLength = N>,
+            N: $crate::hybrid_array::ArraySize<ArrayType<u8> = [u8; U]>,
         {
             #[inline]
             fn import(key: [u8; U]) -> ::core::result::Result<Self, $crate::import::ImportError> {
-                let sk = $crate::keys::SecretKeyBytes::new(key.into());
+                let sk = $crate::keys::SecretKeyBytes::new($crate::hybrid_array::Array(key));
                 ::core::result::Result::Ok(Self(sk))
             }
         }
 
-        impl<N: $crate::generic_array::ArrayLength> $crate::import::Import<&[u8]> for $name<N> {
+        impl<N: $crate::hybrid_array::ArraySize> $crate::import::Import<&[u8]> for $name<N> {
             #[inline]
             fn import(data: &[u8]) -> ::core::result::Result<Self, $crate::import::ImportError> {
                 let bytes = $crate::import::Import::<_>::import(data)?;
@@ -294,7 +293,7 @@ macro_rules! raw_key {
             }
         }
 
-        impl<N: ::generic_array::ArrayLength> ::core::fmt::Debug for $name<N> {
+        impl<N: ::hybrid_array::ArraySize> ::core::fmt::Debug for $name<N> {
             fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                 f.debug_struct(stringify!($name)).finish_non_exhaustive()
             }

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -41,7 +41,7 @@ pub mod test_util;
 mod util;
 
 pub use buggy;
-pub use generic_array;
+pub use hybrid_array;
 #[doc(hidden)]
 pub use spideroak_crypto_derive;
 pub use subtle;

--- a/crates/crypto/src/mac.rs
+++ b/crates/crypto/src/mac.rs
@@ -6,7 +6,7 @@ use core::{
     result::Result,
 };
 
-use generic_array::{ArrayLength, GenericArray};
+use hybrid_array::{Array, ArraySize};
 use subtle::{Choice, ConstantTimeEq};
 use typenum::{IsGreaterOrEqual, IsLess, U32, U48, U64, U65536};
 
@@ -53,7 +53,7 @@ pub trait Mac: Clone + Sized {
     /// The size in octets of a tag used by this [`Mac`].
     ///
     /// Must be at least 32 octets and less than 2¹⁶ octets.
-    type TagSize: ArrayLength + IsGreaterOrEqual<U32> + IsLess<U65536> + 'static;
+    type TagSize: ArraySize + IsGreaterOrEqual<U32> + IsLess<U65536> + 'static;
 
     /// A fixed-length key used by [`new`][Self::new].
     ///
@@ -68,7 +68,7 @@ pub trait Mac: Clone + Sized {
     ///
     /// Must be at least [`MinKeySize`][Self::MinKeySize] or 32
     /// octets (whichever is greater) and less than 2¹⁶ octets.
-    type KeySize: ArrayLength
+    type KeySize: ArraySize
         + IsGreaterOrEqual<Self::MinKeySize>
         + IsGreaterOrEqual<U32>
         + IsLess<U65536>
@@ -81,7 +81,7 @@ pub trait Mac: Clone + Sized {
     /// key used by [`try_new`][Self::try_new].
     ///
     /// Must be at least 32 octets and less than 2¹⁶ octets.
-    type MinKeySize: ArrayLength + IsGreaterOrEqual<U32> + IsLess<U65536> + 'static;
+    type MinKeySize: ArraySize + IsGreaterOrEqual<U32> + IsLess<U65536> + 'static;
 
     /// Attempts to create a new `Mac` with a variable-length
     /// key.
@@ -166,23 +166,23 @@ impl<const N: usize> From<[u8; N]> for Tag<N> {
     }
 }
 
-impl From<GenericArray<u8, U32>> for Tag<32> {
+impl From<Array<u8, U32>> for Tag<32> {
     #[inline]
-    fn from(tag: GenericArray<u8, U32>) -> Self {
+    fn from(tag: Array<u8, U32>) -> Self {
         Self(tag.into())
     }
 }
 
-impl From<GenericArray<u8, U48>> for Tag<48> {
+impl From<Array<u8, U48>> for Tag<48> {
     #[inline]
-    fn from(tag: GenericArray<u8, U48>) -> Self {
+    fn from(tag: Array<u8, U48>) -> Self {
         Self(tag.into())
     }
 }
 
-impl From<GenericArray<u8, U64>> for Tag<64> {
+impl From<Array<u8, U64>> for Tag<64> {
     #[inline]
-    fn from(tag: GenericArray<u8, U64>) -> Self {
+    fn from(tag: Array<u8, U64>) -> Self {
         Self(tag.into())
     }
 }

--- a/crates/crypto/src/rust.rs
+++ b/crates/crypto/src/rust.rs
@@ -148,7 +148,7 @@ impl fmt::Debug for Aes256Gcm {
 #[cfg(feature = "committing-aead")]
 mod committing {
     use aes::cipher::{BlockCipherEncrypt, BlockSizeUser, KeyInit};
-    use generic_array::GenericArray;
+    use hybrid_array::Array;
     use typenum::{Unsigned, U32};
 
     use super::{Aes256Gcm, Sha256};
@@ -173,7 +173,7 @@ mod committing {
             Self(cipher)
         }
 
-        fn encrypt_block(&self, block: &mut GenericArray<u8, Self::BlockSize>) {
+        fn encrypt_block(&self, block: &mut Array<u8, Self::BlockSize>) {
             // Mismatched GenericArray versions, yay.
             let block: &mut [u8; 16] = block.as_mut();
             self.0.encrypt_block(block.into())

--- a/crates/crypto/src/rust.rs
+++ b/crates/crypto/src/rust.rs
@@ -89,8 +89,6 @@ impl Aead for Aes256Gcm {
         let got_tag = self
             .0
             .encrypt_inout_detached(
-                // From<&[T]> for GenericArray<T, _> panics on incorrect length
-                #[allow(clippy::unnecessary_fallible_conversions)]
                 nonce
                     .try_into()
                     .map_err(|_| SealError::InvalidNonceSize(InvalidNonceSize))?,
@@ -114,15 +112,11 @@ impl Aead for Aes256Gcm {
 
         self.0
             .decrypt_inout_detached(
-                // From<&[T]> for GenericArray<T, _> panics on incorrect length
-                #[allow(clippy::unnecessary_fallible_conversions)]
                 nonce
                     .try_into()
                     .map_err(|_| OpenError::InvalidNonceSize(InvalidNonceSize))?,
                 additional_data,
                 data.into(),
-                // From<&[T]> for GenericArray<T, _> panics on incorrect length
-                #[allow(clippy::unnecessary_fallible_conversions)]
                 tag.try_into().map_err(|_| OpenError::InvalidOverheadSize)?,
             )
             .map_err(|_| OpenError::Authentication)
@@ -174,9 +168,7 @@ mod committing {
         }
 
         fn encrypt_block(&self, block: &mut Array<u8, Self::BlockSize>) {
-            // Mismatched GenericArray versions, yay.
-            let block: &mut [u8; 16] = block.as_mut();
-            self.0.encrypt_block(block.into())
+            self.0.encrypt_block(block.as_mut())
         }
     }
 
@@ -317,9 +309,7 @@ macro_rules! ecdh_impl {
 
             #[inline]
             fn try_export_secret(&self) -> Result<SecretKeyBytes<Self::Size>, ExportError> {
-                // Mismatched GenericArray versions, yay.
-                let secret: [u8; FieldBytesSize::<$curve>::USIZE] = self.0.to_bytes().into();
-                Ok(SecretKeyBytes::new(secret.into()))
+                Ok(SecretKeyBytes::new(self.0.to_bytes()))
             }
         }
 
@@ -459,9 +449,7 @@ macro_rules! ecdsa_impl {
 
             #[inline]
             fn try_export_secret(&self) -> Result<SecretKeyBytes<Self::Size>, ExportError> {
-                // Mismatched GenericArray versions, yay.
-                let secret: [u8; FieldBytesSize::<$curve>::USIZE] = self.0.to_bytes().into();
-                Ok(SecretKeyBytes::new(secret.into()))
+                Ok(SecretKeyBytes::new(self.0.to_bytes()))
             }
         }
 

--- a/crates/crypto/src/test_util/hpke.rs
+++ b/crates/crypto/src/test_util/hpke.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 use alloc::vec;
 use core::slice;
 
-use generic_array::GenericArray;
+use hybrid_array::Array;
 use typenum::U64;
 
 use crate::{
@@ -173,7 +173,7 @@ pub fn test_export<K: HpkeKem, F: HpkeKdf, A: HpkeAead + IndCca2, R: Csprng>(rng
         .expect("unable to create recv context");
 
     #[derive(Debug, Default, Eq, PartialEq)]
-    struct Key(GenericArray<u8, U64>);
+    struct Key(Array<u8, U64>);
     impl Expand for Key {
         type Size = U64;
 

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -97,6 +97,11 @@ who = "Jonathan Dygert <jdygert@spideroak.com>"
 criteria = "safe-to-deploy"
 delta = "0.4.2 -> 0.4.3"
 
+[[audits.hybrid-array]]
+who = "Jonathan Dygert <jdygert@spideroak.com>"
+criteria = ["safe-to-deploy", "does-not-implement-crypto"]
+version = "0.4.13"
+
 [[audits.keccak]]
 who = "Ben Zimmerman <bzimmerman@spideroak.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -88,10 +88,6 @@ criteria = "safe-to-deploy"
 version = "0.5.4"
 criteria = "safe-to-deploy"
 
-[[exemptions.const-default]]
-version = "1.0.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.const-oid]]
 version = "0.9.6"
 criteria = "safe-to-deploy"
@@ -156,10 +152,6 @@ criteria = "safe-to-deploy"
 version = "0.14.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.generic-array]]
-version = "1.1.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.getrandom]]
 version = "0.2.2"
 criteria = "safe-to-deploy"
@@ -174,10 +166,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.hmac]]
 version = "0.13.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.hybrid-array]]
-version = "0.4.13"
 criteria = "safe-to-deploy"
 
 [[exemptions.itertools]]


### PR DESCRIPTION
RustCrypto is moving from generic-array to hybrid-array. Following them isn't strictly necessary but eases interop and helps minimize dependencies. hybrid-array has a simpler implementation and provides an "incremental transition path to const generics".